### PR TITLE
Fix tfenv install latest

### DIFF
--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -8,4 +8,4 @@ if [ ${#} -ne 0 ];then
   exit 1
 fi
 
-curlw -sf https://releases.hashicorp.com/terraform/ | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta)[0-9]+)?" | uniq
+curlw -sf https://releases.hashicorp.com/terraform/ | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)[0-9]+)?" | uniq


### PR DESCRIPTION
This PR fixes the tfenv install latest, but installs the alpha2 version.