### PR TITLE
latest without regex means stable + fix tests + fix 0.12.0 alphas

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -33,7 +33,7 @@ if [[ "${version_requested}" =~ ^latest\:.*$ ]]; then
   regex="${version_requested##*\:}"
 elif [[ "${version_requested}" =~ ^latest$ ]]; then
   version="${version_requested}"
-  regex=""
+  regex="^[0-9]\+\.[0-9]\+\.[0-9]\+$"
 else
   version="${version_requested}"
   regex="^${version_requested}$"

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -72,7 +72,14 @@ keybase_bin="$(which keybase 2>/dev/null)"
 shasum_bin="$(which shasum 2>/dev/null)"
 
 version_url="https://releases.hashicorp.com/terraform/${version}"
-tarball_name="terraform_${version}_${os}.zip"
+
+# Thanks for the inconsistency in 0.12-alpha, Hashicorp(!)
+if [[ "${version}" =~ 0.12.0-alpha[3-9] ]]; then
+  tarball_name="terraform_${version}_terraform_${version}_${os}.zip";
+else
+  tarball_name="terraform_${version}_${os}.zip";
+fi;
+
 shasums_name="terraform_${version}_SHA256SUMS"
 
 info "Installing Terraform v${version}"

--- a/test/helpers.sh
+++ b/test/helpers.sh
@@ -2,7 +2,7 @@
 
 check_version() {
   v="${1}"
-  [ -n "$(terraform --version | grep -E "^Terraform v${v}(-dev)?$")" ]
+  [ -n "$(terraform --version | grep -E "^Terraform v${v}((-dev)|( \([a-f0-9]+\)))?$")" ]
 }
 
 cleanup() {

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -19,11 +19,20 @@ source $(dirname $0)/helpers.sh \
 echo "### Install latest version"
 cleanup || error_and_die "Cleanup failed?!"
 
-v=$(tfenv list-remote | head -n 1)
+v=$(tfenv list-remote | grep -e "^[0-9]\+\.[0-9]\+\.[0-9]\+$" | head -n 1)
 (
   tfenv install latest || exit 1
   check_version ${v} || exit 1
 ) || error_and_proceed "Installing latest version ${v}"
+
+echo "### Install latest possibly-unstable version"
+cleanup || error_and_die "Cleanup failed?!"
+
+v=$(tfenv list-remote | head -n 1)
+(
+  tfenv install latest: || exit 1
+  check_version ${v} || exit 1
+) || error_and_proceed "Installing latest possibly-unstable version ${v}"
 
 echo "### Install latest version with Regex"
 cleanup || error_and_die "Cleanup failed?!"
@@ -69,7 +78,7 @@ cleanup || error_and_die "Cleanup failed?!"
 if [ -f ${HOME}/.terraform-version ]; then
   mv ${HOME}/.terraform-version ${HOME}/.terraform-version.bup
 fi
-v=$(tfenv list-remote | head -n 2 | tail -n 1)
+v=$(tfenv list-remote | grep -e "^[0-9]\+\.[0-9]\+\.[0-9]\+$" | head -n 2 | tail -n 1)
 echo "${v}" > ${HOME}/.terraform-version
 (
   tfenv install || exit 1
@@ -77,14 +86,14 @@ echo "${v}" > ${HOME}/.terraform-version
 ) || error_and_proceed "Installing ${HOME}/.terraform-version ${v}"
 
 echo "### Install with parameter and use ~/.terraform-version"
-v=$(tfenv list-remote | head -n 1)
+v=$(tfenv list-remote | grep -e "^[0-9]\+\.[0-9]\+\.[0-9]\+$" | head -n 1)
 (
   tfenv install ${v} || exit 1
   check_version ${v} || exit 1
 ) || error_and_proceed "Use $HOME/.terraform-version ${v}"
 
 echo "### Use with parameter and  ~/.terraform-version"
-v=$(tfenv list-remote | head -n 2 | tail -n 1)
+v=$(tfenv list-remote | grep -e "^[0-9]\+\.[0-9]\+\.[0-9]\+$" | head -n 2 | tail -n 1)
 (
   tfenv use ${v} || exit 1
   check_version ${v} || exit 1


### PR DESCRIPTION
The use of the latest keyword should only install stable releases unless you provide your own regex to match unstable versions.