### PR TITLE
I find this slightly more readable than that grep.

### DIFF
--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -8,4 +8,4 @@ if [ ${#} -ne 0 ];then
   exit 1
 fi
 
-curlw -sf https://releases.hashicorp.com/terraform/ | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)[0-9]+)?" | uniq
+curlw -sf https://releases.hashicorp.com/terraform/ | awk -F"[ /]" '/terraform/ && ! /(alpha|beta|rc)/ {print $8}'


### PR DESCRIPTION
...and it's a little bit faster also:

```bash
➜ hyperfine -w 50 ./1.sh ./2.sh
Benchmark #1: ./1.sh
  Time (mean ± σ):      82.4 ms ±   2.8 ms    [User: 28.2 ms, System: 14.4 ms]
  Range (min … max):    74.1 ms …  86.0 ms    34 runs

Benchmark #2: ./2.sh
  Time (mean ± σ):      81.8 ms ±   2.5 ms    [User: 28.0 ms, System: 13.9 ms]
  Range (min … max):    77.9 ms …  87.9 ms    36 runs

Summary
  './2.sh' ran
    1.01 ± 0.05 times faster than './1.sh'

➜ cat {1,2}.sh
#!/bin/bash
curl -sf https://releases.hashicorp.com/terraform/ | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)[0-9]+)?" | uniq
#!/bin/bash
curl -sf https://releases.hashicorp.com/terraform/ | awk -F"[ /]" '/terraform/ && ! /(alpha|beta|rc)/ { print $8; }'


```