### PR TITLE
fix broken travis ci build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://api.travis-ci.com/tfutils/tfenv.svg?branch=master)](https://travis-ci.com/tfutils/tfenv)
+[![Build Status](https://travis-ci.com/tfutils/tfenv.svg?branch=master)](https://travis-ci.com/tfutils/tfenv)
 
 # tfenv
 [Terraform](https://www.terraform.io/) version manager inspired by [rbenv](https://github.com/rbenv/rbenv)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/tfutils/tfenv.svg?branch=master)](https://travis-ci.org/tfutils/tfenv)
+[![Build Status](https://api.travis-ci.com/tfutils/tfenv.svg?branch=master)](https://travis-ci.com/tfutils/tfenv)
 
 # tfenv
 [Terraform](https://www.terraform.io/) version manager inspired by [rbenv](https://github.com/rbenv/rbenv)


### PR DESCRIPTION
# broken

it's now broken because of travis ci domain changes 
(I guess the repository moved from .org to .com ? )

<img width="258" alt="スクリーンショット 2019-06-06 18 54 19" src="https://user-images.githubusercontent.com/6387224/59024276-89c99800-888c-11e9-9a25-3d7b7249f9d3.png">

# fix

<img width="307" alt="スクリーンショット 2019-06-06 18 44 04" src="https://user-images.githubusercontent.com/6387224/59023612-1b380a80-888b-11e9-8887-149269ce1cd9.png">
