### PR TITLE
Fix version flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1 (unreleased)
+
+ * Fix '--version' flag to return version from CHANGELOG.md when not running from a git checkout.
+
 ## 1.0.0 (June 9, 2019)
 
  * A number of bugfixes and basic script improvements

--- a/libexec/tfenv---version
+++ b/libexec/tfenv---version
@@ -12,7 +12,7 @@
 set -e
 [ -n "${TFENV_DEBUG}" ] && set -x
 
-version="0.6.0"
+version=$(awk '/^##/{ print $2; exit}' "${TFENV_ROOT}"/CHANGELOG.md)
 git_revision=""
 
 if cd "${BASH_SOURCE%/*}" 2>/dev/null && git remote -v 2>/dev/null | grep -q tfenv; then


### PR DESCRIPTION
Was trying to figure out if my `tfenv` had been updated with Homebrew.

```
:~$ tfenv --version
+ [tfenv:22] '[' -z '' ']'
++++ [tfenv:23] readlink_f /usr/local/bin/tfenv
++++ [tfenv:10] local target_file=/usr/local/bin/tfenv
++++ [tfenv:11] local file_name
++++ [tfenv:13] '[' /usr/local/bin/tfenv '!=' '' ']'
+++++ [tfenv:14] dirname /usr/local/bin/tfenv
++++ [tfenv:14] cd /usr/local/bin
+++++ [tfenv:15] basename /usr/local/bin/tfenv
++++ [tfenv:15] file_name=tfenv
+++++ [tfenv:16] readlink tfenv
++++ [tfenv:16] target_file=../Cellar/tfenv/1.0.0/bin/tfenv
++++ [tfenv:13] '[' ../Cellar/tfenv/1.0.0/bin/tfenv '!=' '' ']'
+++++ [tfenv:14] dirname ../Cellar/tfenv/1.0.0/bin/tfenv
++++ [tfenv:14] cd ../Cellar/tfenv/1.0.0/bin
+++++ [tfenv:15] basename ../Cellar/tfenv/1.0.0/bin/tfenv
++++ [tfenv:15] file_name=tfenv
+++++ [tfenv:16] readlink tfenv
++++ [tfenv:16] target_file=
++++ [tfenv:13] '[' '' '!=' '' ']'
+++++ [tfenv:19] pwd -P
++++ [tfenv:19] echo /usr/local/Cellar/tfenv/1.0.0/bin/tfenv
+++ [tfenv:23] dirname /usr/local/Cellar/tfenv/1.0.0/bin/tfenv
++ [tfenv:23] cd /usr/local/Cellar/tfenv/1.0.0/bin/..
++ [tfenv:23] pwd
+ [tfenv:23] TFENV_ROOT=/usr/local/Cellar/tfenv/1.0.0
+ [tfenv:27] export TFENV_ROOT
+ [tfenv:28] PATH=/usr/local/Cellar/tfenv/1.0.0/libexec:/Users/onno/bin:/usr/local/bin:/usr/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/Applications/Wireshark.app/Contents/MacOS:/Users/onno/.local/bin:/Users/onno/go/bin
+ [tfenv:29] export PATH
+ [tfenv:30] export TFENV_DIR=/Users/onno
+ [tfenv:30] TFENV_DIR=/Users/onno
+ [tfenv:40] command=--version
+ [tfenv:41] case "${command}" in
+ [tfenv:48] exec tfenv---version
+ [tfenv---version:15] version=0.6.0
+ [tfenv---version:16] git_revision=
+ [tfenv---version:18] cd /usr/local/Cellar/tfenv/1.0.0/libexec
+ [tfenv---version:18] git remote -v
+ [tfenv---version:18] grep -q tfenv
+ [tfenv---version:23] echo 'tfenv 0.6.0'
tfenv 0.6.0
```

When not running from a git checkout, tfenv 1.0.0 returns a version string of 0.6.0. That's odd! Found it hardcoded in the version command. Not sure what the better workaround would be here... But I updated the hardcoded version for now to ease my confusion.

With this patch applied the brew build returns: `tfenv 1.0.0` when running `tfenv --version`, changing to `tfenv 1.0.1` after the release is added to the changelog.
