### PR TITLE
Use exec for the terraform command to avoid problem in SIGTERM

### DIFF
--- a/libexec/tfenv-exec
+++ b/libexec/tfenv-exec
@@ -19,4 +19,4 @@ set -e
 export TFENV_VERSION="$(tfenv-version-name)"
 TF_BIN_PATH="${TFENV_ROOT}/versions/${TFENV_VERSION}/terraform"
 export PATH="${TF_BIN_PATH}:${PATH}"
-"${TF_BIN_PATH}" "${@}"
+exec "${TF_BIN_PATH}" "${@}"


### PR DESCRIPTION
`tfenv-exec` is used by the `terraform` stub as `exec` but its not done on the `tfenv-exec` command, this causes that `TERM` and other signals land on `bash` instead of `terraform` which should not be the case and could lead to other problems as the "main" process is bash instead of terraform.
It should use `exec` to replace the `bash` process