### PR TITLE
Implement ">=" required_version support

### DIFF
--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -23,15 +23,22 @@ find_min_required() {
   versions="$(grep -h -R required_version --include '*tf' "$root"/* | tr -c -d '0-9. ~=!<>' )"
 
   if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]* ]]; then
-    found_min_required="${BASH_REMATCH[1]}"
+    version_constraint="${BASH_REMATCH[1]}"
 
-    if [[ "${found_min_required}" =~ ^!=.+ ]]; then
-      echo "Error: Min required version is a negation ($found_min_required) - we cannot guess the desired one."
+    if [[ "${version_constraint}" =~ ^!=.+ ]]; then
+      echo "Error: Min required version is a negation ($version_constraint) - we cannot guess the desired one."
       bailout
     else
-      found_min_required="$(echo "$found_min_required" | tr -c -d '0-9.')"
-      #echo "Min required version is detected as ${found_min_required}"
-      echo "${found_min_required}"
+      found_min_required_version="$(echo "$version_constraint" | tr -c -d '0-9.')"
+
+      if [[ "${version_constraint}" == \>\=* ]]; then
+        remote_versions="$(tfenv-list-remote)"
+
+        found_min_required_version="$(tfenv-list-remote | sed '1q;d')" >> "debug.txt"
+      fi
+
+      #echo "Min required version is detected as ${found_min_required_version}"
+      echo "${found_min_required_version}"
       exit 0
     fi
   fi

--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -32,8 +32,6 @@ find_min_required() {
       found_min_required_version="$(echo "$version_constraint" | tr -c -d '0-9.')"
 
       if [[ "${version_constraint}" == \>\=* ]]; then
-        remote_versions="$(tfenv-list-remote)"
-
         found_min_required_version="$(tfenv-list-remote | sed '1q;d')" >> "debug.txt"
       fi
 

--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -32,7 +32,7 @@ find_min_required() {
       found_min_required_version="$(echo "$version_constraint" | tr -c -d '0-9.')"
 
       if [[ "${version_constraint}" == \>\=* ]]; then
-        found_min_required_version="$(tfenv-list-remote | sed '1q;d')" >> "debug.txt"
+        found_min_required_version="$(tfenv-list-remote | sed '1q;d')"
       fi
 
       #echo "Min required version is detected as ${found_min_required_version}"


### PR DESCRIPTION
This adds support for `>=`, by relying on the fact that this library doesn't support multiple constraints - as a result, the version to use when `>=` is the constraint is always the highest version (which is the first version in `tfenv-list-remote`).

I'm not sure what to do about the test - currently it's failing, but will do so whenever a new version is released :/

----

I've got an idea on how to implement support for all the ways of constraining versions, along w/ supporting multiple versions, which I'll have a go at implementing next.

It's a bit hard to write up, in particular b/c I can't decide which is the best thing to loop over, but it's basically that if you have a function "is_version_valid_for_constraint", you can combine that w/ a list of all available versions & a list of all the constraints to perform an intersection.

The result is a list of all the versions supported by all the given constraints; then you just sort that list, and take the "highest" version (which is the very first line).

I'll have a play around, but pretty sure it should be rather straightforward from a logic POV. 
Implementation should also be alright :)