### PR TITLE
Add ability to customize remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ Architecture other than the default amd64 can be specified with the `TFENV_ARCH`
 TFENV_ARCH=arm tfenv install 0.7.9
 ```
 
+### Customize remote
+
+Installing from a remote other than the default https://releases.hashicorp.com can be done by specifying the `TFENV_REMOTE` environment varible
+
+```console
+TFENV_REMOTE=https://example.jfrog.io/artifactory/hashicorp
+```
+
 ### tfenv use &lt;version>
 Switch a version to use
 

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -71,7 +71,8 @@ esac
 keybase_bin="$(command -v keybase 2>/dev/null)"
 shasum_bin="$(command -v shasum 2>/dev/null)"
 
-version_url="https://releases.hashicorp.com/terraform/${version}"
+TFENV_REMOTE="${TFENV_REMOTE:-https://releases.hashicorp.com}"
+version_url="${TFENV_REMOTE}/terraform/${version}"
 
 # Thanks for the inconsistency in 0.12-alpha, Hashicorp(!)
 if [[ "${version}" =~ 0.12.0-alpha[3-9] ]]; then

--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -8,6 +8,7 @@ if [ "${#}" -ne 0 ];then
   exit 1
 fi
 
-curlw -sf "https://releases.hashicorp.com/terraform/" \
+TFENV_REMOTE="${TFENV_REMOTE:-https://releases.hashicorp.com}"
+curlw -sf "${TFENV_REMOTE}/terraform/" \
   | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)[0-9]+)?" \
   | uniq


### PR DESCRIPTION
All our remote servers don't have access to the internet and therefore must use an artifact repository. This allows a different remote to be set so we can.