### PR TITLE
Fix list-remote regex to ignore any version with the -oci postfix

### DIFF
--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -10,5 +10,5 @@ fi
 
 TFENV_REMOTE="${TFENV_REMOTE:-https://releases.hashicorp.com}"
 curlw -sf "${TFENV_REMOTE}/terraform/" \
-  | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)[0-9]+)?" \
+  | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha|oci)[0-9]*)?" \
   | uniq


### PR DESCRIPTION
This may or may not be the correct solution - but we started having issues today when the version 0.11.15-oci was seen by tfenv. When attempting installation of the latest 0.11.x version with the command `tfenv install latest:^0.11.[0-9]*$`, we saw tfenv attempting to install version 0.11.15 - which doesn't exist - and therefore failing.

This change allows `list-remote` to include the full text of the `0.11.15-oci` version in the list, thereby excluding it from potential install candidates when later filtering through a regex.

I would appreciate feedback if this doesn't appear to be the correct approach. Thanks!