### PR TITLE
Add auto-install when no version is available

### DIFF
--- a/libexec/tfenv-exec
+++ b/libexec/tfenv-exec
@@ -17,6 +17,10 @@ set -e
 [ -n "${TFENV_DEBUG}" ] && set -x
 
 export TFENV_VERSION="$(tfenv-version-name)"
+if [ -z ${TFENV_VERSION} ]; then
+  "${TFENV_ROOT}/bin/tfenv" install latest
+  export TFENV_VERSION="$(tfenv-version-name)"
+fi
 TF_BIN_PATH="${TFENV_ROOT}/versions/${TFENV_VERSION}/terraform"
 export PATH="${TF_BIN_PATH}:${PATH}"
 exec "${TF_BIN_PATH}" "${@}"


### PR DESCRIPTION
Implements #134.

This pull request adds the ability for `tfenv` to download the latest version of terraform when no installed version is found.

Please let me know if the idea of this issue sounds good so I can improve this fork by adding tests, better options, automatic version detection via `.terraform-version`, feature switch, etc.