### PR TITLE
fix 0.11.15-oci release in list-remote

### DIFF
--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -10,5 +10,5 @@ fi
 
 TFENV_REMOTE="${TFENV_REMOTE:-https://releases.hashicorp.com}"
 curlw -sf "${TFENV_REMOTE}/terraform/" \
-  | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)[0-9]+)?" \
+  | grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha)[0-9]+|-oci)?" \
   | uniq


### PR DESCRIPTION
not sure why that regex is currently being needed, but it is currently failing on 0.11.15-oci - it cuts off "oci".