### PR TITLE
Fix shebang to use env for bash in bashlog.sh

### DIFF
--- a/lib/bashlog.sh
+++ b/lib/bashlog.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -uo pipefail;
 


### PR DESCRIPTION
This PR fixes issues on recent version on OS X (and possibly other systems) where ancient version of Bash (3.2.x) lurking as /bin/bash.

