### PR TITLE
force tfenv to write over existing zip if it exists

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -274,7 +274,7 @@ fi;
 
 mkdir -p "${dst_path}" || log 'error' "Failed to make directory ${dst_path}";
 
-declare unzip_output="$(unzip "${download_tmp}/${tarball_name}" -d "${dst_path}" || log 'error' 'Tarball unzip failed')";
+declare unzip_output="$(unzip -o "${download_tmp}/${tarball_name}" -d "${dst_path}" || log 'error' 'Tarball unzip failed')";
 while IFS= read -r unzip_line; do
  log 'info' "${unzip_line}";
 done < <(printf '%s\n' "${unzip_output}");


### PR DESCRIPTION
When using `tfenv` in automation, if a previous `tfenv install` failed to unzip without this flag one needs to intervene manually.

This would force the unpack.