### PR TITLE
Bash 3.x compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-before_install:
-  - 'if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; brew install bash; fi' # Bash4 Required
 language: generic
 matrix:
   include:
@@ -10,10 +8,10 @@ matrix:
     - os: linux
       dist: trusty
     - os: osx
-      osx_image: xcode11.2
+      osx_image: xcode11.3
     - os: osx
       osx_image: xcode10.3
-    #- os: osx
-    #  osx_image: xcode9.4  # brew update is excruciatingly slow on xcode9.4
+    - os: osx
+      osx_image: xcode9.4
 script:
   - ./test/run.sh

--- a/bin/terraform
+++ b/bin/terraform
@@ -62,8 +62,8 @@ log 'debug' "program=\"${0##*/}\"";
 
 declare tfenv_path="${TFENV_ROOT}/bin/tfenv";
 
-log 'debug' "Exec: \"${tfenv_path}\" exec \"${@}\"";
-exec "${tfenv_path}" exec "${@}" \
-  || log 'error' "Failed to exec: \"${tfenv_path}\" exec \"${@}\"";
+log 'debug' "Exec: \"${tfenv_path}\" exec \"$*\"";
+exec "${tfenv_path}" exec "$@" \
+  || log 'error' "Failed to exec: \"${tfenv_path}\" exec \"$*\"";
 
 log 'error' 'This line should not be reachable. Something catastrophic has occurred';

--- a/bin/tfenv
+++ b/bin/tfenv
@@ -104,8 +104,8 @@ exit 1;
       } | abort && exit 1;
     fi;
     shift 1;
-    log 'debug' "Exec: \"${command_path}\" \"${@}\"";
-    exec "${command_path}" "${@}";
+    log 'debug' "Exec: \"${command_path}\" \"$*\"";
+    exec "${command_path}" "$@";
     ;;
 esac;
 

--- a/lib/bashlog.sh
+++ b/lib/bashlog.sh
@@ -8,7 +8,7 @@ function _log_exception() {
     BASHLOG_JSON=0;
     BASHLOG_SYSLOG=0;
 
-    log 'error' "Logging Exception: ${@}";
+    log 'error' "Logging Exception: $*";
   );
 };
 export -f _log_exception;
@@ -39,7 +39,7 @@ function log() {
 
   shift 1;
 
-  local line="${@}";
+  local line="$@";
 
   # RFC 5424
   #
@@ -154,7 +154,7 @@ function log() {
       fi;
       ;;
     *)
-      log 'error' "Undefined log level trying to log: ${@}";
+      log 'error' "Undefined log level trying to log: $*";
       ;;
   esac
 };

--- a/libexec/tfenv-exec
+++ b/libexec/tfenv-exec
@@ -95,9 +95,9 @@ fi;
 TF_BIN_PATH="${TFENV_ROOT}/versions/${TFENV_VERSION}/terraform";
 export PATH="${TF_BIN_PATH}:${PATH}";
 log 'debug' "TF_BIN_PATH added to PATH: ${TF_BIN_PATH}";
-log 'debug' "Executing: ${TF_BIN_PATH} ${@}";
+log 'debug' "Executing: ${TF_BIN_PATH} $@";
 
-exec "${TF_BIN_PATH}" "${@}" \
-  || log 'error' "Failed to execute: ${TF_BIN_PATH} ${@}";
+exec "${TF_BIN_PATH}" "$@" \
+  || log 'error' "Failed to execute: ${TF_BIN_PATH} $*";
 
 exit 0;

--- a/test/run.sh
+++ b/test/run.sh
@@ -51,7 +51,7 @@ export PATH="${TFENV_ROOT}/bin:${PATH}";
 
 errors=();
 if [ "${#}" -ne 0 ]; then
-  targets="${@}";
+  targets="$@";
 else
   targets="$(\ls "$(dirname "${0}")" | grep 'test_')";
 fi;

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -67,11 +67,11 @@ test_install_and_use_overridden() {
   tfenv use "${k}" || return 1;
   check_default_version "${v}" || return 1;
   return 0;
-}
+};
 
 declare -a errors=();
 
-log 'info' '### Test Suite: Install and Use'
+log 'info' '### Test Suite: Install and Use';
 
 tests__desc=(
   'latest version'
@@ -84,6 +84,7 @@ tests__desc=(
   'latest version matching regex'
   'specific version'
 );
+
 tests__kv=(
   "$(tfenv list-remote | grep -e "^[0-9]\+\.[0-9]\+\.[0-9]\+$" | head -n 1),latest"
   "$(tfenv list-remote | head -n 1),latest:"
@@ -95,13 +96,14 @@ tests__kv=(
   '0.8.8,latest:^0.8'
   "0.7.13,0.7.13"
 );
-tests_count=${#tests__desc[@]}
+
+tests_count=${#tests__desc[@]};
 
 declare desc kv k v;
 
 for ((test_num=0; test_num<${tests_count}; ++test_num )) ; do
   cleanup || log 'error' 'Cleanup failed?!';
-  desc=${tests__desc[${test_num}]}
+  desc=${tests__desc[${test_num}]};
   kv="${tests__kv[${test_num}]}";
   v="${kv%,*}";
   k="${kv##*,}";
@@ -113,7 +115,7 @@ done;
 
 for ((test_num=0; test_num<${tests_count}; ++test_num )) ; do
   cleanup || log 'error' 'Cleanup failed?!';
-  desc=${tests__desc[${test_num}]}
+  desc=${tests__desc[${test_num}]};
   kv="${tests__kv[${test_num}]}";
   v="${kv%,*}";
   k="${kv##*,}";
@@ -167,16 +169,17 @@ fi;
 log 'info' 'Install invalid specific version';
 cleanup || log 'error' 'Cleanup failed?!';
 
-
 neg_tests__desc=(
   'specific version'
   'latest:word'
 );
+
 neg_tests__kv=(
   '9.9.9'
   "latest:word"
 );
-neg_tests_count=${#neg_tests__desc[@]}
+
+neg_tests_count=${#neg_tests__desc[@]};
 
 for ((test_num=0; test_num<${neg_tests_count}; ++test_num )) ; do
   cleanup || log 'error' 'Cleanup failed?!';

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -57,9 +57,9 @@ function test_uninstall() {
   tfenv uninstall "${v}" || return 1;
   log 'info' 'Confirming uninstall success; an error indicates success:';
   check_active_version "${v}" && return 1 || return 0;
-}
+};
 
-log 'info' '### Test Suite: Uninstall Local Versions'
+log 'info' '### Test Suite: Uninstall Local Versions';
 cleanup || log 'error' 'Cleanup failed?!';
 
 tests__keywords=(
@@ -67,18 +67,20 @@ tests__keywords=(
   '0.11.15-oci'
   'latest'
   'latest:^0.8'
-)
+);
+
 tests__versions=(
   '0.9.1'
   '0.11.15-oci'
   "$(tfenv list-remote | head -n1)"
   "$(tfenv list-remote | grep -e "^0.8" | head -n1)"
-)
-tests_count=${#tests__keywords[@]}
+);
+
+tests_count=${#tests__keywords[@]};
 
 for ((test_num=0; test_num<${tests_count}; ++test_num )) ; do
-  keyword=${tests__keywords[${test_num}]}
-  version=${tests__versions[${test_num}]}
+  keyword=${tests__keywords[${test_num}]};
+  version=${tests__versions[${test_num}]};
   log 'info' "Test $(( ${test_num} + 1 ))/${tests_count}: Testing uninstall of version ${version} via keyword ${keyword}";
   test_uninstall "${keyword}" "${version}" \
     && log info "Test uninstall of version ${version} (via ${keyword}) succeeded" \

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -62,19 +62,27 @@ function test_uninstall() {
 log 'info' '### Test Suite: Uninstall Local Versions'
 cleanup || log 'error' 'Cleanup failed?!';
 
-declare -A tests;
-tests['0.9.1']='0.9.1';
-tests['0.11.15-oci']='0.11.15-oci';
-tests['latest']="$(tfenv list-remote | head -n1)";
-tests['latest:^0.8']="$(tfenv list-remote | grep -e "^0.8" | head -n1)";
+tests__keywords=(
+  '0.9.1'
+  '0.11.15-oci'
+  'latest'
+  'latest:^0.8'
+)
+tests__versions=(
+  '0.9.1'
+  '0.11.15-oci'
+  "$(tfenv list-remote | head -n1)"
+  "$(tfenv list-remote | grep -e "^0.8" | head -n1)"
+)
+tests_count=${#tests__keywords[@]}
 
-declare -i test_num=1;
-for k in "${!tests[@]}"; do
-  log 'info' "Test ${test_num}/${#tests[@]}: Testing uninstall of version ${tests[${k}]} via keyword ${k}";
-  test_uninstall "${k}" "${tests[${k}]}" \
-    && log info "Test uninstall of version ${tests[${k}]} succeeded" \
-    || error_and_proceed "Test uninstall of version ${tests[${k}]} failed";
-  test_num+=1;
+for ((test_num=0; test_num<${tests_count}; ++test_num )) ; do
+  keyword=${tests__keywords[${test_num}]}
+  version=${tests__versions[${test_num}]}
+  log 'info' "Test $(( ${test_num} + 1 ))/${tests_count}: Testing uninstall of version ${version} via keyword ${keyword}";
+  test_uninstall "${keyword}" "${version}" \
+    && log info "Test uninstall of version ${version} (via ${keyword}) succeeded" \
+    || error_and_proceed "Test uninstall of version ${version} (via ${keyword}) failed";
 done;
 
 if [ "${#errors[@]}" -gt 0 ]; then


### PR DESCRIPTION
Default bash installed on macOS is 3.2.57.
And there are some difference in brace expansion for `@` for bash 3.x and 5.x: 

```
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin19)
Copyright (C) 2007 Free Software Foundation, Inc.

$ /bin/bash -c 'set -u; echo "${@}OK"'
/bin/bash: @: unbound variable
```

```
$ /usr/local/bin/bash --version
GNU bash, version 5.0.17(1)-release (x86_64-apple-darwin19.4.0)
Copyright (C) 2019 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

$ /usr/local/bin/bash -c 'set -u; echo "${@}OK"'
OK
```

I suggest to replace `${@}` with `$@` to make tfenv 2 compatible with default bash on macOS:

```
$ /bin/bash -c 'set -u; echo "$@OK"'
OK

$ /usr/local/bin/bash -c 'set -u; echo "$@OK"'
OK
```

I ran `shellcheck` against my changes and it suggested to replace `$@` to `$*` for printing logs, since it was mixing string variables and arrays (https://github.com/koalaman/shellcheck/wiki/SC2145).

All the tests have passed on bash 3.x locally on my mac.

My bash knowledge quite limited, so I'm not aware of the potential drawbacks for this solution.

Closes https://github.com/tfutils/tfenv/issues/180