### PR TITLE
Fixing exit code keybase_logged_in

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -161,9 +161,9 @@ download_signature() {
 
 # Verify signature if verification mechanism (keybase, gpg, etc) is present
 if [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
-  "${keybase_bin}" status | grep -Eq '^Logged in:[[:space:]]*yes';
+  grep -Eq '^Logged in:[[:space:]]*yes' <("${keybase_bin}" status);
   keybase_logged_in="${?}";
-  "${keybase_bin}" list-following | grep -Fq hashicorp;
+  grep -Fq hashicorp <("${keybase_bin}" list-following);
   keybase_following_hc="${?}";
 
   if [[ "${keybase_logged_in}" -ne 0 || "${keybase_following_hc}" -ne 0 ]]; then


### PR DESCRIPTION
Running `tfenv install 0.12.19` with keybase installed and following Hashicorp user still didn't verify Terraforms PGP signature. Upon further investigation, I noticed that `keybase_logged_in` had 141 exit code.

https://stackoverflow.com/a/19120674

```
bash-3.2$ keybase status | grep -Eq '^Logged in:[[:space:]]*yes';
bash-3.2$ echo ${PIPESTATUS[@]}
141 0
```

Changed the grep so it outputs the correct exit code:

```
bash-3.2$ grep -Eq '^Logged in:[[:space:]]*yes' <(keybase status)
bash-3.2$ echo ${PIPESTATUS[@]}
0
bash-3.2$ grep -Eq '^Logged in:[[:space:]]*no' <(keybase status)
bash-3.2$ echo ${PIPESTATUS[@]}
1
```