### PR TITLE
Terraform 0.13.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ If you put a `.terraform-version` file on your project root, or in your home dir
 $ cat .terraform-version
 0.6.16
 
-$ terraform --version
+$ terraform version
 Terraform v0.6.16
 
 Your version of Terraform is out of date! The latest version
@@ -394,12 +394,12 @@ is 0.7.3. You can update by downloading from www.terraform.io
 
 $ echo 0.7.3 > .terraform-version
 
-$ terraform --version
+$ terraform version
 Terraform v0.7.3
 
 $ echo latest:^0.8 > .terraform-version
 
-$ terraform --version
+$ terraform version
 Terraform v0.8.8
 ```
 

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -116,7 +116,7 @@ export -f check_active_version;
 check_installed_version() {
   local v="${1}";
   local bin="${TFENV_ROOT}/versions/${v}/terraform";
-  [ -n "$(${bin} --version | grep -E "^Terraform v${v}((-dev)|( \([a-f0-9]+\)))?$")" ];
+  [ -n "$(${bin} version | grep -E "^Terraform v${v}((-dev)|( \([a-f0-9]+\)))?$")" ];
 };
 export -f check_installed_version;
 

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -109,7 +109,7 @@ export -f curlw;
 
 check_active_version() {
   local v="${1}";
-  [ -n "$(${TFENV_ROOT}/bin/terraform --version | grep -E "^Terraform v${v}((-dev)|( \([a-f0-9]+\)))?$")" ];
+  [ -n "$(${TFENV_ROOT}/bin/terraform version | grep -E "^Terraform v${v}((-dev)|( \([a-f0-9]+\)))?$")" ];
 }
 export -f check_active_version;
 

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -99,6 +99,6 @@ if [ "${version_file}" != "$(tfenv-version-file)" ]; then
   log 'warn' "Default version file overridden by $(tfenv-version-file), changing the default version has no effect";
 fi;
 
-terraform --version 1>/dev/null \
-  || log 'error' "'terraform --version' failed. Something is seriously wrong";
+terraform version 1>/dev/null \
+  || log 'error' "'terraform version' failed. Something is seriously wrong";
 log 'info' "Switching completed";


### PR DESCRIPTION
I tested backwards compatibility of `terraform version` back down to version 0.11.14 successfully. It's probably supported even earlier, but I didn't test further back than that.

I'm already using these changes together with the 0.13.0-beta2 without any problems.