### PR TITLE
Don't fail `tfenv list` in a virgin environment

### DIFF
--- a/libexec/tfenv-list
+++ b/libexec/tfenv-list
@@ -68,9 +68,8 @@ done;
 [[ -x "${TFENV_ROOT}/versions" && -r "${TFENV_ROOT}/versions" ]] \
   || log 'error' "tfenv versions directory is inaccessible: ${TFENV_ROOT}/versions";
 
-version_name="$(tfenv-version-name)" \
-  && log 'debug' "tfenv-version-name reported: ${version_name}" \
-  || log 'error' "tfenv-version-name failed";
+version_name="$(tfenv-version-name 2>/dev/null || true)" \
+  && log 'debug' "tfenv-version-name reported: ${version_name}";
 export version_name;
 
 version_file="$(tfenv-version-file)" \

--- a/libexec/tfenv-list
+++ b/libexec/tfenv-list
@@ -77,9 +77,11 @@ version_file="$(tfenv-version-file)" \
   || log 'error' "tfenv-version-file failed";
 export version_file;
 
+default_set=0
 print_version () {
   if [ "${1}" == "${version_name}" ]; then
     echo "* ${1} (set by ${version_file})";
+    export default_set=1
   else
     echo "  ${1}";
   fi;
@@ -96,3 +98,4 @@ log 'debug' 'Printing versions...';
 for local_version in ${local_versions[@]}; do
   print_version "${local_version}";
 done;
+! ((default_set)) && log 'info' "No default set. Set with 'tfenv use <version>'"


### PR DESCRIPTION
Addresses https://github.com/tfutils/tfenv/issues/187

`tfenv list` fails if no default has been set. This should not occur.

This PR this is addressed with these improvements:

Do not fail `tfenv list` because `tfenv version name` failed, and
don't display its errors.

When `tfenv list` is run and no default is set, helpfully note
that and offer a remedy.