### PR TITLE
Update tfenv-min-required grep logic to prefer working root directory declarations first before recursing. 

### DIFF
--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -73,8 +73,9 @@ see https://www.terraform.io/docs/configuration/terraform.html for details';
 
 find_min_required() {
   local root="${1}";
-
-  versions="$(grep -h -R required_version --include '*tf' "${root}"/* | tr -c -d '0-9. ~=!<>' )";
+  
+  # Only grep recursively if we cannot a required version in base of directory
+  versions="$(grep -h required_version --include '*tf' "${root}"/* || grep -R -h required_version --include '*tf' "${root}"/* | tr -c -d '0-9. ~=!<>' )";
 
   if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]* ]]; then
     found_min_required="${BASH_REMATCH[1]}";


### PR DESCRIPTION
Proposing that tfenv 'min-required' first searches the working directory before recursing. 

In this case if the first grep does not return exit code 0, `||` operator will instead run `grep -R` and keep searching

This prevents unexpected version matches in cases where path based child modules might have their own required_version blocks. Since terraform itself first parses the base directory, it would seem reasonable tfenv would follow suit.