### PR TITLE
min-required correctly finds tagged release versions

### DIFF
--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -74,16 +74,16 @@ see https://www.terraform.io/docs/configuration/terraform.html for details';
 find_min_required() {
   local root="${1}";
 
-  versions="$(grep -h -R required_version --include '*tf' "${root}"/* | tr -c -d '0-9. ~=!<>' )";
+  versions="$(grep -h -R required_version --include '*tf' "${root}"/* | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
 
-  if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]* ]]; then
-    found_min_required="${BASH_REMATCH[1]}";
+  if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]*(-[a-z]+[0-9]+)? ]]; then
+    found_min_required="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
 
     if [[ "${found_min_required}" =~ ^!=.+ ]]; then
       log 'debug' "Error: Min required version is a negation ($found_min_required) - we cannot guess the desired one.";
       bailout;
     else
-      found_min_required="$(echo "$found_min_required" | tr -c -d '0-9.')";
+      found_min_required="$(echo "$found_min_required")";
       #echo "Min required version is detected as ${found_min_required}";
       echo "${found_min_required}";
       exit 0;

--- a/test/test_use_minrequired.sh
+++ b/test/test_use_minrequired.sh
@@ -55,11 +55,15 @@ cleanup || log 'error' 'Cleanup failed?!';
 
 v='0.8.8';
 minv='0.8.0';
+minv_tag='0.13.0-rc1'
 (
   tfenv install "${v}" || true;
   tfenv use "${v}" || exit 1;
   check_active_version "${v}" || exit 1;
 ) || error_and_proceed "Installing specific version ${v}";
+
+
+log 'info' '### Install min-required normal version (#.#.#)';
 
 echo "terraform {
 
@@ -70,6 +74,20 @@ tfenv install min-required;
 tfenv use min-required;
 
 check_active_version "${minv}" || error_and_proceed 'Min required version does not match';
+
+cleanup || log 'error' 'Cleanup failed?!';
+
+log 'info' '### Install min-required tagged version (#.#.#-tag#)'
+
+echo "terraform {
+
+    required_version = \">=${minv_tag}\"
+}" >> min_required.tf;
+
+tfenv install min-required
+tfenv use min-required
+
+check_active_version "${minv_tag}" || error_and_proceed 'Min required version does not match';
 
 cleanup || log 'error' 'Cleanup failed?!';
 


### PR DESCRIPTION
**Problem**: 'tfenv <install|use> min-required' incorrectly interprets a tagged release (ie rc1,beta2,alpha3). 

For example, ">=0.13.0-rc1" is mangled by the translation and results in interpreting min-required as "0.13.1".  This is a bug because at worst results can install and use an undesired version, but mostly is annoying for testing tagged versions. 

**Solution**
The solution is to use a basic regex with 'grep' instead of 'tr' to properly acquire both normal and tagged release versions.  An extra test was added to account for this; the results are below.  

*Notes* 

- This makes 'tfenv min-required' usable with every release of terraform to date (https://releases.hashicorp.com/terraform/)  - - 'grep' is used with basic regex instead of an extended regular expression (egrep/grep -E) to facilitate maximum cross-compatibility between platforms and varying implementations of grep.

**Problem in practice (debug):** 
```
++ grep -h -R required_version --include '*tf' <FILES SCANNED>
++ tr -c -d '0-9. ~=!<>'
+ versions='     = >=0.13.01'
+ [[      = >=0.13.01 =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]* ]]
+ found_min_required='>=0.13.01'
+ [[ >=0.13.01 =~ ^!=.+ ]]
++ echo '>=0.13.01'
++ tr -c -d 0-9.
+ found_min_required=0.13.01
+ echo 0.13.01
+ exit 0
No installed versions of terraform matched 'min-required'
```

**Solution in practice (debug):**
```
++ grep -h -R required_version --include '*tf' <FILES SCANNED>
++ grep -o '\(\d\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?'
+ versions=0.13.0-rc1
+ [[ 0.13.0-rc1 =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]*(-[a-z]+[0-9]+)? ]]
+ found_min_required=0.13.0-rc1
+ [[ 0.13.0-rc1 =~ ^!=.+ ]]
++ echo 0.13.0-rc1
+ found_min_required=0.13.0-rc1
+ echo 0.13.0-rc1
+ exit 0
Installing Terraform v0.13.0-rc1
Downloading release tarball from https://releases.hashicorp.com/terraform/0.13.0-rc1/terraform_0.13.0-rc1_darwin_amd64.zip
######################################################################## 100.0%
Downloading SHA hash file from https://releases.hashicorp.com/terraform/0.13.0-rc1/terraform_0.13.0-rc1_SHA256SUMS
No keybase install found, skipping OpenPGP signature verification
Archive:  tfenv_download.Lubb4P/terraform_0.13.0-rc1_darwin_amd64.zip
  inflating: tfenv/versions/0.13.0-rc1/terraform
Installation of terraform v0.13.0-rc1 successful. To make this your default version, run 'tfenv use 0.13.0-rc1
```