### PR TITLE
Use -r instead of -R for grep

### DIFF
--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -74,7 +74,7 @@ see https://www.terraform.io/docs/configuration/terraform.html for details';
 find_min_required() {
   local root="${1}";
 
-  versions="$(grep -h -R required_version --include '*tf' "${root}"/* | tr -c -d '0-9. ~=!<>' )";
+  versions="$(grep -h -r required_version --include '*tf' "${root}"/* | tr -c -d '0-9. ~=!<>' )";
 
   if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]* ]]; then
     found_min_required="${BASH_REMATCH[1]}";


### PR DESCRIPTION
While running `tfenv install min-required` on alpine, it fails with the error:
```
grep: unrecognized option: R
```

In BusyBox's `grep` (used in Alpine), the only option to do recursive searches is using `-r`.

According to linux's grep man page, `-R` and `-r` do the same thing: https://linux.die.net/man/1/grep

In MacOS, `-r` is also a valid option: https://ss64.com/osx/grep.html