### PR TITLE
fix signature verification bypass due to insufficient hashsum checking

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -227,16 +227,14 @@ if [[ -n "${shasum_bin}" && -x "${shasum_bin}" ]]; then
     "${shasum_bin}" \
       -a 256 \
       -s \
-      -c <(grep -F "${tarball_name}" "${shasums_name}") \
-      || log 'error' 'SHA256 hash does not match!';
-  );
+      -c <(grep -F "${tarball_name}" "${shasums_name}")
+  ) || log 'error' 'SHA256 hash does not match!';
 elif [[ -n "${sha256sum_bin}" && -x "${sha256sum_bin}" ]]; then
   (
     cd "${download_tmp}";
     "${sha256sum_bin}" \
-      -c <(grep -F "${tarball_name}" "${shasums_name}") \
-      || log 'error' 'SHA256 hash does not match!';
-  );
+      -c <(grep -F "${tarball_name}" "${shasums_name}")
+  ) || log 'error' 'SHA256 hash does not match!';
 else
   # Lack of shasum deserves a proper warning
   log 'warn' 'No shasum tool available. Skipping SHA256 hash validation';


### PR DESCRIPTION
The hashsum call is done inside a subshell, hence the error logging
which is responsible for terminating the application on failure must be
chained to the subshell instead of the inner command. Chaining it to the
call inside the subshell would only terminate the subshell ungracefully,
but would not have any effect on the caller.

This effectively is equal to a full signature verification bypass, since
an attacker is able to swap the terraform zip file at will as long as
the hashsum file and the signature are kept unchanged. Before this patch
the installation routine would happily verify the signature of the
hashsum file, the hashsum check in the subshell would fail but the
system wide installation would still take place.

Fixes: 750a8490 (Upgrade to logging, keybase, use of local temp dir)
Since: v0.4.3

Signed-off-by: Levente Polyak <levente@leventepolyak.net>