### PR TITLE
install: make keybase a fall-through verification variant

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -160,25 +160,7 @@ download_signature() {
 };
 
 # Verify signature if verification mechanism (keybase, gpg, etc) is present
-if [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
-  grep -Eq '^Logged in:[[:space:]]*yes' <("${keybase_bin}" status);
-  keybase_logged_in="${?}";
-  grep -Fq hashicorp <("${keybase_bin}" list-following);
-  keybase_following_hc="${?}";
-
-  if [[ "${keybase_logged_in}" -ne 0 || "${keybase_following_hc}" -ne 0 ]]; then
-    log 'warn' 'Unable to verify OpenPGP signature unless logged into keybase and following hashicorp';
-  else
-    download_signature;
-    "${keybase_bin}" pgp verify \
-      -S hashicorp \
-      -d "${download_tmp}/${shasums_name}.sig" \
-      -i "${download_tmp}/${shasums_name}" \
-      && log 'debug' 'SHA256SUMS signature matched' \
-      || log 'error' 'SHA256SUMS signature does not match!';
-  fi;
-
-elif [[ -f "${TFENV_ROOT}/use-gnupg" ]]; then
+if [[ -f "${TFENV_ROOT}/use-gnupg" ]]; then
   # GnuPG uses the user's keyring, and any web-of-trust or local signatures or
   # anything else they have setup.  This is the crazy-powerful mode which is
   # overly confusing to newcomers.  We don't support it without the user creating
@@ -215,6 +197,23 @@ elif [[ -f "${TFENV_ROOT}/use-gpgv" ]]; then
       "${download_tmp}/${shasums_name}.sig" \
       "${download_tmp}/${shasums_name}" \
       || log 'error' 'PGP signature rejected';
+  fi;
+elif [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
+  grep -Eq '^Logged in:[[:space:]]*yes' <("${keybase_bin}" status);
+  keybase_logged_in="${?}";
+  grep -Fq hashicorp <("${keybase_bin}" list-following);
+  keybase_following_hc="${?}";
+
+  if [[ "${keybase_logged_in}" -ne 0 || "${keybase_following_hc}" -ne 0 ]]; then
+    log 'warn' 'Unable to verify OpenPGP signature unless logged into keybase and following hashicorp';
+  else
+    download_signature;
+    "${keybase_bin}" pgp verify \
+      -S hashicorp \
+      -d "${download_tmp}/${shasums_name}.sig" \
+      -i "${download_tmp}/${shasums_name}" \
+      && log 'debug' 'SHA256SUMS signature matched' \
+      || log 'error' 'SHA256SUMS signature does not match!';
   fi;
 else
   # Warning about this avoids an unwarranted sense of confidence in the SHA check


### PR DESCRIPTION
Prefer verification variants that require explicit opt-in by specifying
use-gnupg or use-gpgv. Use keybase as a fall-through verification
method in case nothing else has been explicitly requested.

In case a curated gpgv keyring is used for the trust, there is no point
in forcing to use keybase just because it is available while we
explicitly requested to use gpgv instead.