### PR TITLE
fixes the error when using auto-install with regex

### DIFF
--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -49,7 +49,7 @@ fi;
 for dir in libexec bin; do
   case ":${PATH}:" in
     *:${TFENV_ROOT}/${dir}:*) log 'debug' "\$PATH already contains '${TFENV_ROOT}/${dir}', not adding it again";;
-    *) 
+    *)
       log 'debug' "\$PATH does not contain '${TFENV_ROOT}/${dir}', prepending and exporting it now";
       export PATH="${TFENV_ROOT}/${dir}:${PATH}";
       ;;
@@ -90,6 +90,8 @@ if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
   if [ -n "${version}" ]; then
     log 'debug' "Version selected: ${version}";
     TFENV_VERSION="${version}"
+  elif [ "${TFENV_AUTO_INSTALL:-true}" == "true" ]; then
+    log 'debug' "No installed versions of terraform matched '${TFENV_VERSION}'";
   else
     log 'error' "No installed versions of terraform matched '${TFENV_VERSION}'";
   fi;


### PR DESCRIPTION
Issue described here:
https://github.com/tfutils/tfenv/issues/216

Local testing done:

Listing without the version installed (reported in the issue):
```bash
[mpescetto:~/test/test2]$ tfenv list
  0.12.29
  0.12.28
  0.12.26
  0.12.24
  0.12.18
  0.11.14
  0.11.11
```

Getting auto-install to work:
```bash
[mpescetto:~/test/test2]$ terraform -version
version 'latest:^0.13' is not installed (set by /Users/mpescetto/test/test2/.terraform-version). Installing now as TFENV_AUTO_INSTALL==true
Installing Terraform v0.13.4
Downloading release tarball from https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_darwin_amd64.zip
######################################################################## 100.0%
Downloading SHA hash file from https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_SHA256SUMS
No keybase install found, skipping OpenPGP signature verification
Archive:  tfenv_download.63317i/terraform_0.13.4_darwin_amd64.zip
  inflating: /usr/local/Cellar/tfenv/2.0.0/versions/0.13.4/terraform
Installation of terraform v0.13.4 successful. To make this your default version, run 'tfenv use 0.13.4'
/usr/local/Cellar/tfenv/2.0.0/libexec/tfenv-exec: line 100: /usr/local/Cellar/tfenv/2.0.0/versions/latest:^0.13/terraform: No such file or directory
```