### PR TITLE
Use ggrep on Mac with Homebrew

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -159,6 +159,15 @@ download_signature() {
     || log 'error' 'SHA256SUMS signature download failed';
 };
 
+# If on MacOS with Homebrew, use GNU grep
+# This allows keybase login detection to work on Mac
+if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
+  if ! [ $(which ggrep) ]; then
+    brew install grep;
+  fi
+  alias grep=ggrep;
+fi
+
 # Verify signature if verification mechanism (keybase, gpg, etc) is present
 if [[ -n "${keybase_bin}" && -x "${keybase_bin}" ]]; then
   grep -Eq '^Logged in:[[:space:]]*yes' <("${keybase_bin}" status);


### PR DESCRIPTION
Allow the Keybase check to work on MacOS by using `ggrep`.

Fixes #189 
Fixes #195 