### PR TITLE
Fix tfenv-min-required

### DIFF
--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -75,7 +75,7 @@ find_min_required() {
   local root="${1}";
   
   # Only grep recursively if we cannot a required version in base of directory
-  versions="$(grep -h required_version --include '*tf' "${root}"/* || grep -h -R required_version --include '*tf' "${root}"/* | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
+  versions="$( echo $(grep -h required_version --include '*tf' "${root}"/* || grep -h -R required_version --include '*tf' "${root}"/*) | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
 
   if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]*(-[a-z]+[0-9]+)? ]]; then
     found_min_required="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"


### PR DESCRIPTION
A recent PR seems to have broken min-required functionlaiy. https://github.com/tfutils/tfenv/pull/203  Attempting to fix here.

Example behavior seen currently (run from a terraform project directory):
```
$ grep -h required_version --include '*tf' "${PWD}"/* || grep -h -R required_version --include '*tf' "${PWD}"/* | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?'
  required_version = ">= 0.13.2"
```

Behavior after changes in this PR:
```
$ echo $(grep -h required_version --include '*tf' "${PWD}"/* || grep -h -R required_version --include '*tf' "${PWD}"/*) | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?'
0.13.2
```