### PR TITLE
schlueter: Fix tfenv list in virgin environments

### DIFF
--- a/libexec/tfenv-list
+++ b/libexec/tfenv-list
@@ -68,9 +68,8 @@ done;
 [[ -x "${TFENV_ROOT}/versions" && -r "${TFENV_ROOT}/versions" ]] \
   || log 'error' "tfenv versions directory is inaccessible: ${TFENV_ROOT}/versions";
 
-version_name="$(tfenv-version-name)" \
-  && log 'debug' "tfenv-version-name reported: ${version_name}" \
-  || log 'error' "tfenv-version-name failed";
+version_name="$(tfenv-version-name 2>/dev/null || true)" \
+  && log 'debug' "tfenv-version-name reported: ${version_name}";
 export version_name;
 
 if [ -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
@@ -82,9 +81,13 @@ else
 fi
 export version_source;
 
+# Register for whether a default terraform version has yet been set
+declare -i default_set=0;
+
 print_version () {
   if [ "${1}" == "${version_name}" ]; then
     echo "* ${1} (set by ${version_source})";
+    default_set=1
   else
     echo "  ${1}";
   fi;
@@ -101,3 +104,7 @@ log 'debug' 'Printing versions...';
 for local_version in ${local_versions[@]}; do
   print_version "${local_version}";
 done;
+
+[ "${default_set}" -eq 0 ] && log 'info' "No default set. Set with 'tfenv use <version>'";
+
+exit 0;

--- a/test/test_list.sh
+++ b/test/test_list.sh
@@ -60,9 +60,14 @@ for v in 0.7.2 0.7.13 0.9.1 0.9.2 0.9.11; do
     || error_and_proceed "Install of version ${v} failed";
 done;
 
-tfenv use 0.9.11
+log 'info' '## Ensuring tfenv list success with no default set';
+tfenv list \
+  && log 'debug' "List succeeded with no default set" \
+  || error_and_proceed "List failed with no default set";
 
-log 'info' '## Comparing "tfenv list" to expectations';
+tfenv use 0.9.11;
+
+log 'info' '## Comparing "tfenv list" with default set';
 result="$(tfenv list)";
 expected="$(cat << EOS
 * 0.9.11 (set by $(tfenv version-file))
@@ -73,9 +78,9 @@ expected="$(cat << EOS
 EOS
 )";
 
-if [ "${expected}" != "${result}" ]; then
-  error_and_proceed "List mismatch.\nExpected:\n${expected}\nGot:\n${result}";
-fi;
+[ "${expected}" == "${result}" ] \
+  && log 'info' 'List matches expectation.' \
+  || error_and_proceed "List mismatch.\nExpected:\n${expected}\nGot:\n${result}";
 
 if [ "${#errors[@]}" -gt 0 ]; then
   log 'warn' "===== The following list tests failed =====";


### PR DESCRIPTION
tfenv-list: Helpfully note when no default is set
Don't let tfenv-version-name fail tfenv-list

Closes #193 
Resolves #187