### PR TITLE
Do not grep recursively for min-required

### DIFF
--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -74,8 +74,7 @@ see https://www.terraform.io/docs/configuration/terraform.html for details';
 find_min_required() {
   local root="${1}";
   
-  # Only grep recursively if we cannot a required version in base of directory
-  versions="$( echo $(grep -h required_version --include '*tf' "${root}"/* || grep -h -R required_version --include '*tf' "${root}"/*) | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
+  versions="$( echo $(grep -h required_version --include '*tf' "${root}"/* ) | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
 
   if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]*(-[a-z]+[0-9]+)? ]]; then
     found_min_required="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"

--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -74,7 +74,7 @@ see https://www.terraform.io/docs/configuration/terraform.html for details';
 find_min_required() {
   local root="${1}";
   
-  versions="$( echo $(grep -h required_version --include '*tf' "${root}"/* ) | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
+  versions="$( echo $(grep -h required_version "${root}"/*.tf 2>/dev/null ) | grep  -o '\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
 
   if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*[0-9]+[0-9.]+)[^0-9]*(-[a-z]+[0-9]+)? ]]; then
     found_min_required="${BASH_REMATCH[1]}${BASH_REMATCH[2]}"


### PR DESCRIPTION
Resolve #225 by not inappropriately searching subdirectories of the root module for required_version.

As per #225:

> If your root module is calling another module with a higher required minimum version, then your root module implicitly requires that version and should have its minimum version set accordingly. tfenv is not in a position to determine the minimum version of all possible module sources, whether stored locally on disk, within the same directory as the root component or elsewhere, or stored in an external git repository or registry. It can only depend on the root module informing as to the minimum version necessary for all dependent modules.