### PR TITLE
Suppress stderr from cat command in tfenv-version-name

### DIFF
--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -69,7 +69,7 @@ declare requested="${requested_arg}";
 
 if [ -z "${requested_arg}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
   version_source_suffix=" (set by $(tfenv-version-file))";
-  requested="$(cat "$(tfenv-version-file)" || true)";
+  requested="$(cat "$(tfenv-version-file)" 2>/dev/null || true)";
 elif [ -z "${requested_arg}" ]; then
   version_source_suffix=' (set by TFENV_TERRAFORM_VERSION)';
   requested="${TFENV_TERRAFORM_VERSION}";

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -68,7 +68,7 @@ if [ -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
     && log 'debug' "TFENV_VERSION_FILE retrieved from tfenv-version-file: ${TFENV_VERSION_FILE}" \
     || log 'error' 'Failed to retrieve TFENV_VERSION_FILE from tfenv-version-file';
 
-  TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" || true)" \
+  TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" 2>/dev/null || true)" \
     && log 'debug' "TFENV_VERSION specified in TFENV_VERSION_FILE: ${TFENV_VERSION}";
 
   TFENV_VERSION_SOURCE="${TFENV_VERSION_FILE}";


### PR DESCRIPTION
In a clean environment, this is the output you see:

```
tfenv[master] $ ./bin/tfenv version-name
cat: /Users/itse/Desktop/testing_repos/tfenv/version: No such file or directory
Version could not be resolved (set by /Users/itse/Desktop/testing_repos/tfenv/version or tfenv use <version>)
```

I'm thinking we could suppress the stderr of the cat command since there's already an error message indicating the issue. This is a small cosmetic change so feel free to close if you do not think this adds any value. Thanks for looking!

Edit: I noticed a similar behavior on `tfenv-use` so I updated that as well!