### PR TITLE
Download latest version if user uses regex and TFENV_AUTO_INSTALL is true

### DIFF
--- a/0.12
+++ b/0.12
@@ -1,5 +1,0 @@
-Terraform v0.15.0
-on linux_amd64
-
-Your version of Terraform is out of date! The latest version
-is 0.15.3. You can update by downloading from https://www.terraform.io/downloads.html

--- a/0.12
+++ b/0.12
@@ -1,0 +1,5 @@
+Terraform v0.15.0
+on linux_amd64
+
+Your version of Terraform is out of date! The latest version
+is 0.15.3. You can update by downloading from https://www.terraform.io/downloads.html

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -60,10 +60,7 @@ done;
 # Begin Script Body #
 #####################
 
-[ -d "${TFENV_ROOT}/versions" ] \
-  || log 'error' 'No versions of terraform installed. Please install one with: tfenv install';
-
-if [ -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
+if [[ -z "${TFENV_TERRAFORM_VERSION:-""}" ]]; then
   TFENV_VERSION_FILE="$(tfenv-version-file)" \
     && log 'debug' "TFENV_VERSION_FILE retrieved from tfenv-version-file: ${TFENV_VERSION_FILE}" \
     || log 'error' 'Failed to retrieve TFENV_VERSION_FILE from tfenv-version-file';
@@ -90,37 +87,45 @@ if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
     log 'debug' "'latest' keyword does not use regex";
   fi;
 
-  version="$(\find "${TFENV_ROOT}/versions" -type d -exec basename {} \; \
-    | tail -n +2 \
-    | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
-    | grep -e "${regex}" \
-    | head -n 1)";
+  if [[ -d "${TFENV_ROOT}/versions" ]]; then
+    local_version="$(\find "${TFENV_ROOT}/versions" -type d -exec basename {} \; \
+      | tail -n +2 \
+      | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
+      | grep -e "${regex}" \
+      | head -n 1)";
+  else
+     local_version='' # To avoid 'unbound variable' error
+  fi
 
   if [[ "${TFENV_AUTO_INSTALL:-true}" == "true" ]]; then
     log 'debug' "Trying to find the remote version using the regex: ${regex}";
     remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)"
     if [[ -n "${remote_version}" ]]; then
-        if [[ "${version}" != "${remote_version}" ]]; then
-          log 'debug' "The installed version '${version}' does not much the remote version '${remote_version}'";
+        if [[ "${local_version}" != "${remote_version}" ]]; then
+          log 'debug' "The installed version '${local_version}' does not much the remote version '${remote_version}'";
           TFENV_VERSION="${remote_version}"
         else
-          TFENV_VERSION="${version}"
+          TFENV_VERSION="${local_version}"
         fi
     else
       log 'error' "No versions matching '${requested}' found in remote";
     fi
   else
-    [[ -n "${version}" ]] && TFENV_VERSION="${version}" \
-      || log 'error' "No installed versions of terraform matched '${TFENV_VERSION}'";
+    if [[ -n "${local_version}" ]]; then
+      TFENV_VERSION="${local_version}"
+    else
+      log 'error' "No installed versions of terraform matched '${TFENV_VERSION}'";
+    fi
   fi
 else
   log 'debug' 'TFENV_VERSION does not use "latest" keyword';
 fi;
 
-[ -z "${TFENV_VERSION}" ] \
-  && log 'error' "Version could not be resolved (set by ${TFENV_VERSION_SOURCE} or tfenv use <version>)";
+if [[ -z "${TFENV_VERSION}" ]]; then
+  log 'error' "Version could not be resolved (set by ${TFENV_VERSION_SOURCE} or tfenv use <version>)";
+fi
 
-if [ ! -d "${TFENV_ROOT}/versions/${TFENV_VERSION}" ]; then
+if [[ ! -d "${TFENV_ROOT}/versions/${TFENV_VERSION}" ]]; then
   log 'debug' "version '${TFENV_VERSION}' is not installed (set by ${TFENV_VERSION_SOURCE})";
 fi;
 

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -90,14 +90,13 @@ if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
     log 'debug' "'latest' keyword does not use regex";
   fi;
 
+  declare local_version = '';
   if [[ -d "${TFENV_ROOT}/versions" ]]; then
     local_version="$(\find "${TFENV_CONFIG_DIR}/versions/" -type d -exec basename {} \; \
       | tail -n +2 \
       | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
       | grep -e "${regex}" \
       | head -n 1)";
-  else
-     local_version=''; # To avoid 'unbound variable' error
   fi;
 
   if [[ "${TFENV_AUTO_INSTALL:-true}" == "true" ]]; then

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -91,7 +91,7 @@ if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
   fi;
 
   declare local_version='';
-  if [[ -d "${TFENV_ROOT}/versions" ]]; then
+  if [[ -d "${TFENV_CONFIG_DIR}/versions" ]]; then
     local_version="$(\find "${TFENV_CONFIG_DIR}/versions/" -type d -exec basename {} \; \
       | tail -n +2 \
       | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -86,8 +86,8 @@ if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
     regex="${TFENV_VERSION##*\:}";
     log 'debug' "'latest' keyword uses regex: ${regex}";
   else
-    regex='.*'; # Just saves a separate command below without the grep
-    log 'debug' "'latest' keyword does not use regex";
+    regex="^[0-9]\+\.[0-9]\+\.[0-9]\+$";
+    log 'debug' "Version uses latest keyword alone. Forcing regex to match stable versions only: ${regex}";
   fi;
 
   declare local_version='';

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -90,7 +90,7 @@ if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
     log 'debug' "'latest' keyword does not use regex";
   fi;
 
-  declare local_version = '';
+  declare local_version='';
   if [[ -d "${TFENV_ROOT}/versions" ]]; then
     local_version="$(\find "${TFENV_CONFIG_DIR}/versions/" -type d -exec basename {} \; \
       | tail -n +2 \

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -86,7 +86,7 @@ if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
     regex="${TFENV_VERSION##*\:}";
     log 'debug' "'latest' keyword uses regex: ${regex}";
   else
-    regex='.*'; # Just saves a seperate command below without the grep
+    regex='.*'; # Just saves a separate command below without the grep
     log 'debug' "'latest' keyword does not use regex";
   fi;
 
@@ -96,13 +96,23 @@ if [[ "${TFENV_VERSION}" =~ ^latest.*$ ]]; then
     | grep -e "${regex}" \
     | head -n 1)";
 
-  if [ -n "${version}" ]; then
-    log 'debug' "Version selected: ${version}";
-    TFENV_VERSION="${version}"
+  if [[ "${TFENV_AUTO_INSTALL:-true}" == "true" ]]; then
+    log 'debug' "Trying to find the remote version using the regex: ${regex}";
+    remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)"
+    if [[ -n "${remote_version}" ]]; then
+        if [[ "${version}" != "${remote_version}" ]]; then
+          log 'debug' "The installed version '${version}' does not much the remote version '${remote_version}'";
+          TFENV_VERSION="${remote_version}"
+        else
+          TFENV_VERSION="${version}"
+        fi
+    else
+      log 'error' "No versions matching '${requested}' found in remote";
+    fi
   else
-    log 'error' "No installed versions of terraform matched '${TFENV_VERSION}'";
-  fi;
-
+    [[ -n "${version}" ]] && TFENV_VERSION="${version}" \
+      || log 'error' "No installed versions of terraform matched '${TFENV_VERSION}'";
+  fi
 else
   log 'debug' 'TFENV_VERSION does not use "latest" keyword';
 fi;
@@ -115,4 +125,3 @@ if [ ! -d "${TFENV_ROOT}/versions/${TFENV_VERSION}" ]; then
 fi;
 
 echo "${TFENV_VERSION}";
-


### PR DESCRIPTION
Closes: https://github.com/tfutils/tfenv/issues/216

flow:
- set latest:^0.12 in .terraform-version
- check latest available remove version
- compare the latest available remote version and the latest installed version
- install latest available remote version if it is newer
