### PR TITLE
Fix issue #210 - allow non-numeric values for DEBUG

### DIFF
--- a/bin/terraform
+++ b/bin/terraform
@@ -35,7 +35,7 @@ export TFENV_ROOT;
 if [ -n "${TFENV_HELPERS:-""}" ]; then
   log 'debug' 'TFENV_HELPERS is set, not sourcing helpers again';
 else
-  [ "${TFENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${TFENV_ROOT}/lib/helpers.sh";
+  [ "${TFENV_DEBUG:-0}" -gt 0 ] && >&2 echo "[DEBUG] Sourcing helpers from ${TFENV_ROOT}/lib/helpers.sh";
   if source "${TFENV_ROOT}/lib/helpers.sh"; then
     log 'debug' 'Helpers sourced successfully';
   else

--- a/bin/tfenv
+++ b/bin/tfenv
@@ -35,7 +35,7 @@ export TFENV_ROOT;
 if [ -n "${TFENV_HELPERS:-""}" ]; then
   log 'debug' 'TFENV_HELPERS is set, not sourcing helpers again';
 else
-  [ "${TFENV_DEBUG:-0}" -gt 0 ] && echo "[DEBUG] Sourcing helpers from ${TFENV_ROOT}/lib/helpers.sh";
+  [ "${TFENV_DEBUG:-0}" -gt 0 ] && >&2 echo "[DEBUG] Sourcing helpers from ${TFENV_ROOT}/lib/helpers.sh";
   if source "${TFENV_ROOT}/lib/helpers.sh"; then
     log 'debug' 'Helpers sourced successfully';
   else

--- a/lib/bashlog.sh
+++ b/lib/bashlog.sh
@@ -31,7 +31,7 @@ function log() {
 
   local level="${1}";
   local upper="$(echo "${level}" | awk '{print toupper($0)}')";
-  local debug_level="${DEBUG:-0}";
+  local debug_level="${TFENV_DEBUG:-0}";
   local stdout_colours="${BASHLOG_COLOURS:-1}";
   local stdout_extra="${BASHLOG_EXTRA:-0}";
 

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -24,7 +24,8 @@ else
 fi;
 export TFENV_ROOT;
 
-if [ "${TFENV_DEBUG:-0}" -gt 0 ]; then
+# Only reset DEBUG if TFENV_DEBUG is set, and DEBUG is unset or already a number
+if [ "${TFENV_DEBUG:-0}" -gt 0 ] && [[ "${DEBUG:-0}" =~ ^[0-9]+$ ]]; then
   [ "${DEBUG:-0}" -gt "${TFENV_DEBUG:-0}" ] || export DEBUG="${TFENV_DEBUG:-0}";
   if [[ "${TFENV_DEBUG}" -gt 2 ]]; then
     export PS4='+ [${BASH_SOURCE##*/}:${LINENO}] ';

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -24,9 +24,11 @@ else
 fi;
 export TFENV_ROOT;
 
-# Only reset DEBUG if TFENV_DEBUG is set, and DEBUG is unset or already a number
-if [ "${TFENV_DEBUG:-0}" -gt 0 ] && [[ "${DEBUG:-0}" =~ ^[0-9]+$ ]]; then
-  [ "${DEBUG:-0}" -gt "${TFENV_DEBUG:-0}" ] || export DEBUG="${TFENV_DEBUG:-0}";
+if [ "${TFENV_DEBUG:-0}" -gt 0 ]; then
+  # Only reset DEBUG if TFENV_DEBUG is set, and DEBUG is unset or already a number
+  if [[ "${DEBUG:-0}" =~ ^[0-9]+$ ]] && [ "${DEBUG:-0}" -gt "${TFENV_DEBUG:-0}" ]; then
+    export DEBUG="${TFENV_DEBUG:-0}";
+  fi;
   if [[ "${TFENV_DEBUG}" -gt 2 ]]; then
     export PS4='+ [${BASH_SOURCE##*/}:${LINENO}] ';
     set -x;


### PR DESCRIPTION
As documented in issue #210, lots of applications use the DEBUG env var, as a result, `tfenv` needs to be resilient in honoring non-numeric values.  This PR addresses that.

Additionally, I ran into an issue where this terraform show command would fail when running with debug:
```
TFENV_DEBUG=1 terraform show -json tmp.out
```

In this case, show should output JSON only, but it also had:
```
[DEBUG] Sourcing helpers from /Users/kaz/scratch/tfenv/lib/helpers.sh
```
which made it difficult to process that JSON.  This PR changes that output to stderr so as to not screw up the output