### PR TITLE
Fix ARM64 support for old terraform versions

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -88,7 +88,12 @@ case "$(uname -m)" in
     # There is no arm64 support for versions:
     # < 0.11.15
     # >= 0.12.0, < 0.12.30
-    if [[ "${version}" =~ 0\.(([0-9]|1[0-1])).[0-1][0-4]?$ || "${version}" =~ 0\.12\.[0-2][0-9]?$ ]]; then
+    # >= 0.13.0, < 0.13.5
+    if [[ "${version}" =~ 0\.(([0-9]|10))\.\d* ||
+          "${version}" =~ 0\.11\.(([0-9]|1[0-4]))$ ||
+          "${version}" =~ 0\.12\.(([0-9]|[1-2][0-9]))$ ||
+          "${version}" =~ 0\.13\.[0-4]$
+    ]]; then
       TFENV_ARCH="${TFENV_ARCH:-amd64}";
     else
       TFENV_ARCH="${TFENV_ARCH:-arm64}";

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -88,12 +88,10 @@ case "$(uname -m)" in
     # There is no arm64 support for versions:
     # < 0.11.15
     # >= 0.12.0, < 0.12.30
-    if [[ "${version}" =~ (0\.(([0-9]|1[0-1])).[0-1][0-4]?$) ]] || [[ "${version}" =~ 0\.12\.[0-2][0-9]?$ ]] ; then
+    if [[ "${version}" =~ 0\.(([0-9]|1[0-1])).[0-1][0-4]?$ || "${version}" =~ 0\.12\.[0-2][0-9]?$ ]]; then
       TFENV_ARCH="${TFENV_ARCH:-amd64}";
-      echo "1"
     else
       TFENV_ARCH="${TFENV_ARCH:-arm64}";
-      echo "2"
     fi;
     ;;
   *)

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -85,7 +85,16 @@ fi;
 # Add support of ARM64 for Linux & Apple Silicon
 case "$(uname -m)" in
   aarch64* | arm64*)
-    TFENV_ARCH="${TFENV_ARCH:-arm64}";
+    # There is no arm64 support for versions:
+    # < 0.11.15
+    # >= 0.12.0, < 0.12.30
+    if [[ "${version}" =~ (0\.(([0-9]|1[0-1])).[0-1][0-4]?$) ]] || [[ "${version}" =~ 0\.12\.[0-2][0-9]?$ ]] ; then
+      TFENV_ARCH="${TFENV_ARCH:-amd64}";
+      echo "1"
+    else
+      TFENV_ARCH="${TFENV_ARCH:-arm64}";
+      echo "2"
+    fi;
     ;;
   *)
     TFENV_ARCH="${TFENV_ARCH:-amd64}";


### PR DESCRIPTION
There are no old Terraform **ARM64** versions in hashicorp repo

Examples:
[0.11.14](https://releases.hashicorp.com/terraform/0.11.14/)
[0.12.29](https://releases.hashicorp.com/terraform/0.12.29/)
[0.6.16](https://releases.hashicorp.com/terraform/0.6.16/)


How to reproduce issue:
```
# Run docker container
docker run -it --rm openresty/openresty:1.19.3.2-3-alpine-fat /bin/bash
# Install tfenv
apk add git && git clone https://github.com/tfutils/tfenv.git ~/.tfenv && ln -s ~/.tfenv/bin/* /usr/local/bin

# Install terraform 0.11.14

tfenv install 0.11.14
Installing Terraform v0.11.14
Downloading release tarball from https://releases.hashicorp.com/terraform/0.11.14/terraform_0.11.14_linux_arm64.zip                                 curl: (22) The requested URL returned error: 403

Tarball download failed
```