### PR TITLE
ci: add macos-11 and windows 2022

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,10 +33,11 @@ jobs:
     strategy:
       matrix:
         os:
-          # - 'macos-11.0' # Not yet available
+          - 'macos-11'
           - 'macos-10.15'
           - 'ubuntu-20.04'
           - 'ubuntu-18.04'
+          - 'windows-2022'
           - 'windows-2019'
     steps:
       - uses: 'actions/checkout@v2'


### PR DESCRIPTION
See https://github.com/actions/virtual-environments/ for the supported OSs