### PR TITLE
Fix #301: find min-required version through -chdir

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -84,7 +84,20 @@ export -f curlw;
 
 function check_active_version() {
   local v="${1}";
-  [ -n "$(${TFENV_ROOT}/bin/terraform version | grep -E "^Terraform v${v}((-dev)|( \([a-f0-9]+\)))?$")" ];
+  local maybe_chdir=;
+  if [ -n "${2:-}" ]; then
+      maybe_chdir="-chdir=${2}";
+  fi;
+
+  local active_version="$(${TFENV_ROOT}/bin/terraform ${maybe_chdir} version | grep '^Terraform')";
+
+  if ! grep -E "^Terraform v${v}((-dev)|( \([a-f0-9]+\)))?\$" <(echo "${active_version}"); then
+    log 'debug' "Expected version ${v} but found ${active_version}";
+    return 1;
+  fi;
+
+  log 'debug' "Active version ${v} as expected";
+  return 0;
 };
 export -f check_active_version;
 
@@ -113,6 +126,8 @@ function cleanup() {
   rm -rf ./.terraform-version;
   log 'debug' "Deleting ${pwd}/min_required.tf";
   rm -rf ./min_required.tf;
+  log 'debug' "Deleting ${pwd}/chdir-dir";
+  rm -rf ./chdir-dir;
 };
 export -f cleanup;
 

--- a/lib/tfenv-exec.sh
+++ b/lib/tfenv-exec.sh
@@ -3,6 +3,17 @@
 set -uo pipefail;
 
 function tfenv-exec() {
+  for _arg in ${@:1}; do
+    if [[ "$_arg" == -chdir=* ]]; then
+      log 'debug' "Found -chdir arg: ${_arg#-chdir=}"
+      export TFENV_DIR="${PWD}/${_arg#-chdir=}";
+      break;
+    else
+      export TFENV_DIR="${PWD}";
+    fi;
+    log 'info' "Set TFENV_DIR to $TFENV_DIR"
+  done;
+
   log 'debug' 'Getting version from tfenv-version-name';
   TFENV_VERSION="$(tfenv-version-name)" \
   && log 'debug' "TFENV_VERSION is ${TFENV_VERSION}" \

--- a/lib/tfenv-exec.sh
+++ b/lib/tfenv-exec.sh
@@ -4,25 +4,25 @@ set -uo pipefail;
 
 function tfenv-exec() {
   for _arg in ${@:1}; do
-    if [[ "$_arg" == -chdir=* ]]; then
-      log 'debug' "Found -chdir arg: ${_arg#-chdir=}"
+    if [[ "${_arg}" == -chdir=* ]]; then
+      log 'debug' "Found -chdir arg: ${_arg#-chdir=}";
       export TFENV_DIR="${PWD}/${_arg#-chdir=}";
       break;
     else
       export TFENV_DIR="${PWD}";
     fi;
-    log 'info' "Set TFENV_DIR to $TFENV_DIR"
+    log 'info' "Set TFENV_DIR to ${TFENV_DIR}";
   done;
 
   log 'debug' 'Getting version from tfenv-version-name';
   TFENV_VERSION="$(tfenv-version-name)" \
-  && log 'debug' "TFENV_VERSION is ${TFENV_VERSION}" \
-  || {
-    # Errors will be logged from tfenv-version name,
-    # we don't need to trouble STDERR with repeat information here
-    log 'debug' 'Failed to get version from tfenv-version-name';
-    return 1;
-  };
+    && log 'debug' "TFENV_VERSION is ${TFENV_VERSION}" \
+    || {
+      # Errors will be logged from tfenv-version name,
+      # we don't need to trouble STDERR with repeat information here
+      log 'debug' 'Failed to get version from tfenv-version-name';
+      return 1;
+    };
   export TFENV_VERSION;
 
   if [ ! -d "${TFENV_CONFIG_DIR}/versions/${TFENV_VERSION}" ]; then
@@ -31,7 +31,7 @@ function tfenv-exec() {
       TFENV_VERSION_SOURCE="$(tfenv-version-file)";
     else
       TFENV_VERSION_SOURCE='TFENV_TERRAFORM_VERSION';
-    fi
+    fi;
       log 'info' "version '${TFENV_VERSION}' is not installed (set by ${TFENV_VERSION_SOURCE}). Installing now as TFENV_AUTO_INSTALL==true";
       tfenv-install;
     else

--- a/lib/tfenv-min-required.sh
+++ b/lib/tfenv-min-required.sh
@@ -3,7 +3,7 @@
 set -uo pipefail;
 
 function tfenv-min-required() {
-  local path="${1:-.}";
+  local path="${1:-${TFENV_DIR:-.}}";
 
   local versions="$( echo $(cat ${path}/{*.tf,*.tf.json} 2>/dev/null | grep -Eh '^\s*[^#]*\s*required_version') | grep -o '[~=!<>]\{0,2\}\s*\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
 

--- a/test/test_use_minrequired.sh
+++ b/test/test_use_minrequired.sh
@@ -120,6 +120,24 @@ echo 'min-required' > .terraform-version;
 
 cleanup || log 'error' 'Cleanup failed?!';
 
+
+log 'info' '### Install min-required with TFENV_AUTO_INSTALL & -chdir';
+
+minv='1.1.0';
+
+mkdir -p chdir-dir
+echo "terraform {
+  required_version = \">=${minv}\"
+}" >> chdir-dir/min_required.tf;
+echo 'min-required' > chdir-dir/.terraform-version
+
+(
+  TFENV_AUTO_INSTALL=true terraform -chdir=chdir-dir version;
+  check_active_version "${minv}" chdir-dir;
+) || error_and_proceed 'Min required version from -chdir does not match';
+
+cleanup || log 'error' 'Cleanup failed?!';
+
 if [ "${#errors[@]}" -gt 0 ]; then
   log 'warn' '===== The following use_minrequired tests failed =====';
   for error in "${errors[@]}"; do


### PR DESCRIPTION
This commit makes it possible to use `min-required` with the terraform
configuration (including the `required_version` spec) in a subdirectory
as `terraform -chdir=subdir`.

Prior to this commit, this behaviour does not work (`-chdir` cannot be
used with `tfenv`'s `terraform` wrapper & `min-required` version)
because `tfenv` expects to find the configuration in `$PWD`.

Fixes #301 
Fixes #273 