### PR TITLE
Include support of min-required syntax in TFENV_TERRAFORM_VERSION

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ TFENV_CONFIG_DIR="$XDG_CONFIG_HOME/tfenv"
 String (Default: "")
 
 If not empty string, this variable overrides Terraform version, specified in [.terraform-version files](#terraform-version-file).
-`latest` and `latest:<regex>` syntax are also supported.
+`min-required`, `latest` and `latest:<regex>` syntax are also supported.
 [`tfenv install`](#tfenv-install-version) and [`tfenv use`](#tfenv-use-version) command also respects this variable.
 
 e.g.

--- a/libexec/tfenv-exec
+++ b/libexec/tfenv-exec
@@ -72,7 +72,7 @@ done;
 # Begin Script Body #
 #####################
 
-if [[ "${TFENV_TERRAFORM_VERSION}" =~ ^min-required$ ]]; then
+if [[ ! -z ${TFENV_TERRAFORM_VERSION+x} ]] && [[ "${TFENV_TERRAFORM_VERSION}" =~ ^min-required$ ]]; then
   log 'info' 'TFENV_TERRAFORM_VERSION set to "min-required". Detecting minimum required version...';
   min_required="$(tfenv-min-required)" || log 'error' 'tfenv-min-required failed';
   log 'info' "Minimum required version detected: ${min_required}";

--- a/libexec/tfenv-exec
+++ b/libexec/tfenv-exec
@@ -74,10 +74,17 @@ done;
 
 if [[ "${TFENV_TERRAFORM_VERSION-}" =~ ^min-required$ ]]; then
   log 'info' 'TFENV_TERRAFORM_VERSION set to "min-required". Detecting minimum required version...';
-  min_required="$(tfenv-min-required)" || log 'error' 'tfenv-min-required failed';
-  log 'info' "Minimum required version detected: ${min_required}";
-  TFENV_VERSION=${min_required}
-else
+  min_required="$(tfenv-min-required)"
+  if [ $? -ne 0 ]; then
+    log 'info' 'tfenv-min-required failed, falling-back to tfenv-version-name';
+    TFENV_TERRAFORM_VERSION="";
+  else
+    log 'info' "Minimum required version detected: ${min_required}";
+    TFENV_VERSION=${min_required};
+  fi;
+fi;
+
+if [ -z "${TFENV_VERSION+x}" ]; then
   log 'debug' 'Getting version from tfenv-version-name';
   TFENV_VERSION="$(tfenv-version-name)" \
     && log 'debug' "TFENV_VERSION is ${TFENV_VERSION}" \

--- a/libexec/tfenv-exec
+++ b/libexec/tfenv-exec
@@ -72,7 +72,7 @@ done;
 # Begin Script Body #
 #####################
 
-if [[ ! -z ${TFENV_TERRAFORM_VERSION+x} ]] && [[ "${TFENV_TERRAFORM_VERSION}" =~ ^min-required$ ]]; then
+if [[ "${TFENV_TERRAFORM_VERSION-}" =~ ^min-required$ ]]; then
   log 'info' 'TFENV_TERRAFORM_VERSION set to "min-required". Detecting minimum required version...';
   min_required="$(tfenv-min-required)" || log 'error' 'tfenv-min-required failed';
   log 'info' "Minimum required version detected: ${min_required}";

--- a/libexec/tfenv-exec
+++ b/libexec/tfenv-exec
@@ -72,15 +72,23 @@ done;
 # Begin Script Body #
 #####################
 
-log 'debug' 'Getting version from tfenv-version-name';
-TFENV_VERSION="$(tfenv-version-name)" \
-  && log 'debug' "TFENV_VERSION is ${TFENV_VERSION}" \
-  || {
-    # Errors will be logged from tfenv-version name,
-    # we don't need to trouble STDERR with repeat information here
-    log 'debug' 'Failed to get version from tfenv-version-name';
-    exit 1;
-  };
+if [[ "${TFENV_TERRAFORM_VERSION}" =~ ^min-required$ ]]; then
+  log 'info' 'TFENV_TERRAFORM_VERSION set to "min-required". Detecting minimum required version...';
+  min_required="$(tfenv-min-required)" || log 'error' 'tfenv-min-required failed';
+  log 'info' "Minimum required version detected: ${min_required}";
+  TFENV_VERSION=${min_required}
+else
+  log 'debug' 'Getting version from tfenv-version-name';
+  TFENV_VERSION="$(tfenv-version-name)" \
+    && log 'debug' "TFENV_VERSION is ${TFENV_VERSION}" \
+    || {
+      # Errors will be logged from tfenv-version name,
+      # we don't need to trouble STDERR with repeat information here
+      log 'debug' 'Failed to get version from tfenv-version-name';
+      exit 1;
+    };
+fi;
+
 export TFENV_VERSION;
 
 if [ ! -d "${TFENV_CONFIG_DIR}/versions/${TFENV_VERSION}" ]; then


### PR DESCRIPTION
This PR adds support of `min-required` in the `TFENV_TERRAFORM_VERSION` environment variable.

This way, the `.terraform-version` files can be skipped as the source of truth for the Terraform version can be inferred from the [Terraform Block](https://www.terraform.io/docs/language/settings/index.html#terraform-block-syntax) directly.

The feature is **opt-in**.