### PR TITLE
Fix arm64 support for darwin (MacOS) versions < 1.0.2

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -88,7 +88,12 @@ case "$(uname -m)" in
     # There is no arm64 support for versions:
     # < 0.11.15
     # >= 0.12.0, < 0.12.30
-    if [[ "${version}" =~ 0\.(([0-9]|1[0-1])).[0-1][0-4]?$ || "${version}" =~ 0\.12\.[0-2][0-9]?$ ]]; then
+    # >= 0.13.0, < 0.13.5
+    if [[ "${version}" =~ 0\.(([0-9]|10))\.\d* ||
+          "${version}" =~ 0\.11\.(([0-9]|1[0-4]))$ ||
+          "${version}" =~ 0\.12\.(([0-9]|[1-2][0-9]))$ ||
+          "${version}" =~ 0\.13\.[0-4]$
+    ]]; then
       TFENV_ARCH="${TFENV_ARCH:-amd64}";
     else
       TFENV_ARCH="${TFENV_ARCH:-arm64}";

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -107,12 +107,12 @@ esac;
 case "$(uname -s)" in
   Darwin*)
     # ARM for darwin only is available for versions >= 1.0.2
-    if [[ "${version}" =~ 1\.0\.(([2-9]|1[0-1]]))$ || 
-	  ! "${version}" =~ 0\.\d*.\d*
+    if [[ "${version}" =~ 1\.0\.[0-1]$ || 
+	  "${version}" =~ 0\.\d*.\d*
     ]]; then
-      os="darwin_${TFENV_ARCH}";
-    else
       os="darwin_amd64";
+    else
+      os="darwin_${TFENV_ARCH}";
     fi;
     ;;
   MINGW64*)

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -88,12 +88,10 @@ case "$(uname -m)" in
     # There is no arm64 support for versions:
     # < 0.11.15
     # >= 0.12.0, < 0.12.30
-    if [[ "${version}" =~ (0\.(([0-9]|1[0-1])).[0-1][0-4]?$) ]] || [[ "${version}" =~ 0\.12\.[0-2][0-9]?$ ]] ; then
+    if [[ "${version}" =~ 0\.(([0-9]|1[0-1])).[0-1][0-4]?$ || "${version}" =~ 0\.12\.[0-2][0-9]?$ ]]; then
       TFENV_ARCH="${TFENV_ARCH:-amd64}";
-      echo "1"
     else
       TFENV_ARCH="${TFENV_ARCH:-arm64}";
-      echo "2"
     fi;
     ;;
   *)

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -106,7 +106,14 @@ esac;
 
 case "$(uname -s)" in
   Darwin*)
-    os="darwin_${TFENV_ARCH}";
+    # ARM for darwin only is available for versions >= 1.0.2
+    if [[ "${version}" =~ 1\.0\.(([2-9]|1[0-1]]))$ || 
+	  ! "${version}" =~ 0\.\d*.\d*
+    ]]; then
+      os="darwin_${TFENV_ARCH}";
+    else
+      os="darwin_amd64";
+    fi;
     ;;
   MINGW64*)
     os="windows_${TFENV_ARCH}";
@@ -118,7 +125,7 @@ case "$(uname -s)" in
     os="windows_${TFENV_ARCH}";
     ;;
   FreeBSD*)
-    os="freebsd_${TFENV_ARCH}"
+    os="freebsd_${TFENV_ARCH}";
     ;;
   *)
     os="linux_${TFENV_ARCH}";

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -85,7 +85,16 @@ fi;
 # Add support of ARM64 for Linux & Apple Silicon
 case "$(uname -m)" in
   aarch64* | arm64*)
-    TFENV_ARCH="${TFENV_ARCH:-arm64}";
+    # There is no arm64 support for versions:
+    # < 0.11.15
+    # >= 0.12.0, < 0.12.30
+    if [[ "${version}" =~ (0\.(([0-9]|1[0-1])).[0-1][0-4]?$) ]] || [[ "${version}" =~ 0\.12\.[0-2][0-9]?$ ]] ; then
+      TFENV_ARCH="${TFENV_ARCH:-amd64}";
+      echo "1"
+    else
+      TFENV_ARCH="${TFENV_ARCH:-arm64}";
+      echo "2"
+    fi;
     ;;
   *)
     TFENV_ARCH="${TFENV_ARCH:-amd64}";


### PR DESCRIPTION
I added the case to avoid downloading ARM for versions < 1.0.2 in MacOS. @Zordrak. I don't know if I need to first send the PR to Samusia fork