### PR TITLE
Handle new alpha versioning syntax

### DIFF
--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -73,4 +73,4 @@ remote_versions="$(curlw -sSf "${TFENV_REMOTE}/terraform/")" \
 
 #log 'debug' "Remote versions available: ${remote_versions}"; # Even in debug mode this is too verbose
 
-grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha|oci)[0-9]*)?" <<<"${remote_versions}" | uniq;
+grep -o -E "[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha|oci)-?[0-9]*)?" <<<"${remote_versions}" | uniq;


### PR DESCRIPTION
Handles new alpha versioning syntax as of latest 1.2.0 alpha build:
```
1.2.0-alpha-20220328
1.1.0-alpha20211029
1.1.0-alpha20211020
```
(grep previously trimmed off the date, so binary location was wrong)