### PR TITLE
chore(log): make TFENV_DIR update a debug-level log

### DIFF
--- a/lib/tfenv-exec.sh
+++ b/lib/tfenv-exec.sh
@@ -11,7 +11,7 @@ function tfenv-exec() {
     else
       export TFENV_DIR="${PWD}";
     fi;
-    log 'info' "Set TFENV_DIR to ${TFENV_DIR}";
+    log 'debug' "Set TFENV_DIR to ${TFENV_DIR}";
   done;
 
   log 'debug' 'Getting version from tfenv-version-name';


### PR DESCRIPTION
After this update, the new message:  `Set TFENV_DIR to <x>`  is always sent to stdout. This means using Terraform outputs in our build scrips fail.

For example, we use the following to look for files that need formatting: `terraform fmt --list=true -diff=true -write=false` and if the line count is greater than 0 (indicating a file per line needing formatting) our build fails.

After the recent [commit](https://github.com/tfutils/tfenv/commit/2d9002484a1b1ed65fae48d6e8e25cdea7aadecd)  we now have the output from `terraform fmt` polluted with the the `Set TFENV_DIR to <x>`, which means we can no longer rely on Terraform's (native) output.

I believe this log severity should be `debug` to avoid having to work around `tfenv` output when running "native" Terraform commands.