### PR TITLE
Improve `TFENV_ARCH` initialisation for Apple Silicon Macs

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -82,48 +82,54 @@ if [ -f "${dst_path}/terraform" ]; then
   exit 0;
 fi;
 
+case "$(uname -s)" in
+  Darwin*)
+    kernel="darwin";
+    ;;
+  MINGW64*)
+    kernel="windows";
+    ;;
+  MSYSNT*)
+    kernel="windows";
+    ;;
+  CYGWINNT*)
+    kernel="windows";
+    ;;
+  FreeBSD*)
+    kernel="freebsd";
+    ;;
+  *)
+    kernel="linux";
+    ;;
+esac;
+
 # Add support of ARM64 for Linux & Apple Silicon
 case "$(uname -m)" in
   aarch64* | arm64*)
-    # There is no arm64 support for versions:
-    # < 0.11.15
-    # >= 0.12.0, < 0.12.30
-    # >= 0.13.0, < 0.13.5
-    if [[ "${version}" =~ 0\.(([0-9]|10))\.\d* ||
-          "${version}" =~ 0\.11\.(([0-9]|1[0-4]))$ ||
-          "${version}" =~ 0\.12\.(([0-9]|[1-2][0-9]))$ ||
-          "${version}" =~ 0\.13\.[0-4]$
-    ]]; then
-      TFENV_ARCH="${TFENV_ARCH:-amd64}";
-    else
-      TFENV_ARCH="${TFENV_ARCH:-arm64}";
-    fi;
+    case "${kernel}" in
+      "linux")
+        # There is no arm64 support for versions:
+        # < 0.11.15
+        # >= 0.12.0, < 0.12.30
+        # >= 0.13.0, < 0.13.5
+        if [[ "${version}" =~ 0\.(([0-9]|10))\.\d* ||
+              "${version}" =~ 0\.11\.(([0-9]|1[0-4]))$ ||
+              "${version}" =~ 0\.12\.(([0-9]|[1-2][0-9]))$ ||
+              "${version}" =~ 0\.13\.[0-4]$
+        ]]; then
+          TFENV_ARCH="${TFENV_ARCH:-amd64}";
+        else
+          TFENV_ARCH="${TFENV_ARCH:-arm64}";
+        fi;
+      ;;
+    esac;
     ;;
   *)
     TFENV_ARCH="${TFENV_ARCH:-amd64}";
     ;;
 esac;
 
-case "$(uname -s)" in
-  Darwin*)
-    os="darwin_${TFENV_ARCH}";
-    ;;
-  MINGW64*)
-    os="windows_${TFENV_ARCH}";
-    ;;
-  MSYS_NT*)
-    os="windows_${TFENV_ARCH}";
-    ;;
-  CYGWIN_NT*)
-    os="windows_${TFENV_ARCH}";
-    ;;
-  FreeBSD*)
-    os="freebsd_${TFENV_ARCH}";
-    ;;
-  *)
-    os="linux_${TFENV_ARCH}";
-    ;;
-esac;
+os="${kernel}_${TFENV_ARCH}"
 
 keybase_bin="$(command -v keybase 2>/dev/null)";
 shasum_bin="$(command -v shasum 2>/dev/null)";

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -123,7 +123,7 @@ case "$(uname -m)" in
         fi;
       ;;
       "darwin")
-        # No M1 builds before 1.0.2
+        # No Apple Silicon builds before 1.0.2
         if [[ "${version}" =~ 0\..+$ || "${version}" =~ 1\.0\.0|1$
         ]]; then
           TFENV_ARCH="${TFENV_ARCH:-amd64}";

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -122,6 +122,15 @@ case "$(uname -m)" in
           TFENV_ARCH="${TFENV_ARCH:-arm64}";
         fi;
       ;;
+      "darwin")
+        # No M1 builds before 1.0.2
+        if [[ "${version}" =~ 0\..+$ || "${version}" =~ 1\.0\.0|1$
+        ]]; then
+          TFENV_ARCH="${TFENV_ARCH:-amd64}";
+        else
+          TFENV_ARCH="${TFENV_ARCH:-arm64}";
+        fi;
+      ;;
     esac;
     ;;
   *)


### PR DESCRIPTION
Fixes #350. I've changed the order of the `uname -s` and `uname -m` steps in order to make this work. As such, I've created a new variable, `kernel`, that is set during the `uname -s` `case` statement. `kernel` is then used when setting `TFENV_ARCH` when `aarch-64 | arm64` is found, and also later when setting the `os` variable. Hope it makes sense.

I've checked this against the current `tfenv` installed on my machine (version 3.0.0, installed via brew), and it works where the current version fails (`tfenv` == 3.0.0, `tfenv-deniz` == this branch):

```
$ tfenv install 0.11.15
Installing Terraform v0.11.15
Downloading release tarball from https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_darwin_arm64.zip
curl: (22) The requested URL returned error: 404                                                   

Tarball download failed

$ tfenv-deniz install 0.11.15
Installing Terraform v0.11.15
Downloading release tarball from https://releases.hashicorp.com/terraform/0.11.15/terraform_0.11.15_darwin_amd64.zip
############################################################################################# 100.0%
...
```