### PR TITLE
[Darwin AMR64] Fix version parsing for amd64 fallback tarballs

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -85,14 +85,11 @@ fi;
 # Add support of ARM64 for Linux & Apple Silicon
 case "$(uname -m)" in
   aarch64* | arm64*)
-    # There is no arm64 support for versions:
-    # < 0.11.15
-    # >= 0.12.0, < 0.12.30
-    # >= 0.13.0, < 0.13.5
-    if [[ "${version}" =~ 0\.(([0-9]|10))\.\d* ||
-          "${version}" =~ 0\.11\.(([0-9]|1[0-4]))$ ||
-          "${version}" =~ 0\.12\.(([0-9]|[1-2][0-9]))$ ||
-          "${version}" =~ 0\.13\.[0-4]$
+    # There is no arm64 support for all versions below v1.0.2:
+    # https://github.com/hashicorp/terraform/issues/27257#issuecomment-875834420
+    if [[
+      "${version}" =~ 0\.(([0-9]|1[0-5]))\.\d* ||
+      "${version}" == 1\.0\.[0-1]$
     ]]; then
       TFENV_ARCH="${TFENV_ARCH:-amd64}";
     else


### PR DESCRIPTION
## Summary
Some days ago I switched to Apple Silicon.
I still work with a lot of legacy Terraform codebases, so I realized the version parsing not being accurate. 

Terraform releases started to ship Darwin ARM64 packages with [v1.0.2](https://github.com/hashicorp/terraform/issues/27257#issuecomment-875834420).
In the meantime there where a lot of patch releases currently unable to be installed, as `tfenv` always tries to fetch the Darwin ARM64 versions instead of the AMD64 fallback one.

## Notes
This PR straightens the version parsing, letting `tfenv` fetching AMD64 tarballs for all `pre-v1.0.2` releases on Darwin ARM64. 

## Current behavior
```console
TFENV_DEBUG=1 tfenv install min-required
[DEBUG] Sourcing helpers from /opt/homebrew/Cellar/tfenv/3.0.0/lib/helpers.sh
DEBUG trap set
Helpers sourced successfully
$PATH does not contain '/opt/homebrew/Cellar/tfenv/3.0.0/libexec', prepending and exporting it now
$PATH does not contain '/opt/homebrew/Cellar/tfenv/3.0.0/bin', prepending and exporting it now
Setting TFENV_DIR to /Users/n3ph/Repositories/ops/terraform/ctp-vault/vault/vault-config
tfenv argument is: install
Long argument provided: install
Resulting command-path: /opt/homebrew/Cellar/tfenv/3.0.0/libexec/tfenv-install
Exec: "/opt/homebrew/Cellar/tfenv/3.0.0/libexec/tfenv-install" "min-required"
TFENV_HELPERS is set, not sourcing helpers again
$PATH already contains '/opt/homebrew/Cellar/tfenv/3.0.0/libexec', not adding it again
$PATH already contains '/opt/homebrew/Cellar/tfenv/3.0.0/bin', not adding it again
Resolving version with: tfenv-resolve-version min-required
TFENV_HELPERS is set, not sourcing helpers again
$PATH already contains '/opt/homebrew/Cellar/tfenv/3.0.0/libexec', not adding it again
$PATH already contains '/opt/homebrew/Cellar/tfenv/3.0.0/bin', not adding it again
Version Requested: min-required
Detecting minimum required version...
Determined min-required to be '0.12.31' (/Users/n3ph/Repositories/ops/terraform/ctp-vault/vault/vault-config/versions.tf:2: required_version = 0.12.31)
Minimum required version detected: 0.12.31
Version is explicit: 0.12.31. Regex enforces the version: ^0.12.31$
Processing install for version 0.12.31, using regex ^0.12.31$
TFENV_HELPERS is set, not sourcing helpers again
$PATH already contains '/opt/homebrew/Cellar/tfenv/3.0.0/libexec', not adding it again
$PATH already contains '/opt/homebrew/Cellar/tfenv/3.0.0/bin', not adding it again
TFENV_REMOTE: https://releases.hashicorp.com
Installing Terraform v0.12.31
Setting curl progress bar with "-#"
Downloading release tarball from https://releases.hashicorp.com/terraform/0.12.31/terraform_0.12.31_darwin_arm64.zip
#=#=-  #       #                                                                                                                                                                                                                                               #=O#-     #        #                                                                                                                                                                                                                                           curl: (22) The requested URL returned error: 404

Tarball download failed
```