### PR TITLE
Fix arm64 support darwin

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -107,12 +107,12 @@ esac;
 case "$(uname -s)" in
   Darwin*)
     # ARM for darwin only is available for versions >= 1.0.2
-    if [[ "${version}" =~ 1\.0\.(([2-9]|1[0-1]]))$ || 
-	  ! "${version}" =~ 0\.\d*.\d*
+    if [[ "${version}" =~ 1\.0\.[0-1]$ || 
+	  "${version}" =~ 0\.\d*.\d*
     ]]; then
-      os="darwin_${TFENV_ARCH}";
-    else
       os="darwin_amd64";
+    else
+      os="darwin_${TFENV_ARCH}";
     fi;
     ;;
   MINGW64*)

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -106,7 +106,14 @@ esac;
 
 case "$(uname -s)" in
   Darwin*)
-    os="darwin_${TFENV_ARCH}";
+    # ARM for darwin only is available for versions >= 1.0.2
+    if [[ "${version}" =~ 1\.0\.(([2-9]|1[0-1]]))$ || 
+	  ! "${version}" =~ 0\.\d*.\d*
+    ]]; then
+      os="darwin_${TFENV_ARCH}";
+    else
+      os="darwin_amd64";
+    fi;
     ;;
   MINGW64*)
     os="windows_${TFENV_ARCH}";


### PR DESCRIPTION
With this improvement, the tf versions without Darwin ARM64 support are replaced by the AMD64 version. This solves the following issue:

```
tfenv install 1.0.0

Installing Terraform v1.0.0
Downloading release tarball from https://releases.hashicorp.com/terraform/1.0.0/terraform_1.0.0_darwin_arm64.zip
curl: (22) The requested URL returned error: 404                                                                                                                                     

Tarball download failed