### PR TITLE
Refactor readlink_f to common helpers

### DIFF
--- a/bin/terraform
+++ b/bin/terraform
@@ -11,19 +11,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "${target_file%/*}" || early_death "Failed to 'cd \$(${target_file%/*})' while trying to determine TFENV_ROOT";
-      file_name="${target_file##*/}" || early_death "Failed to '\"${target_file##*/}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
   TFENV_SHIM=$(readlink_f "${0}")
   TFENV_ROOT="${TFENV_SHIM%/*/*}";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to determine TFENV_ROOT";

--- a/bin/tfenv
+++ b/bin/tfenv
@@ -11,19 +11,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "${target_file%/*}" || early_death "Failed to 'cd \$(${target_file%/*})' while trying to determine TFENV_ROOT";
-      file_name="${target_file##*/}" || early_death "Failed to '\"${target_file##*/}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
   TFENV_SHIM=$(readlink_f "${0}")
   TFENV_ROOT="${TFENV_SHIM%/*/*}";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to determine TFENV_ROOT";

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -8,7 +8,7 @@ readlink_f() {
   local file_name;
 
   while [ "${target_file}" != "" ]; do
-    cd "${target_file%/*}" || early_death "Failed to 'cd \$(${target_file%/*})'";
+    cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(${target_file%/*})'";
     file_name="${target_file##*/}" || early_death "Failed to '\"${target_file##*/}\"'";
     target_file="$(readlink "${file_name}")";
   done;

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -2,20 +2,22 @@
 
 set -uo pipefail;
 
+# http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+readlink_f() {
+  local target_file="${1}";
+  local file_name;
+
+  while [ "${target_file}" != "" ]; do
+    cd "${target_file%/*}" || early_death "Failed to 'cd \$(${target_file%/*})'";
+    file_name="${target_file##*/}" || early_death "Failed to '\"${target_file##*/}\"'";
+    target_file="$(readlink "${file_name}")";
+  done;
+
+  echo "$(pwd -P)/${file_name}";
+};
+export -f readlink_f;
+
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "${target_file%/*}" || early_death "Failed to 'cd \$(${target_file%/*})' while trying to determine TFENV_ROOT";
-      file_name="${target_file##*/}" || early_death "Failed to '\"${target_file##*/}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
   TFENV_SHIM=$(readlink_f "${0}")
   TFENV_ROOT="${TFENV_SHIM%/*/*}";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to determine TFENV_ROOT";

--- a/lib/tfenv-exec.sh
+++ b/lib/tfenv-exec.sh
@@ -5,8 +5,10 @@ set -uo pipefail;
 function tfenv-exec() {
   for _arg in ${@:1}; do
     if [[ "${_arg}" == -chdir=* ]]; then
-      log 'debug' "Found -chdir arg. Setting TFENV_DIR to: ${_arg#-chdir=}";
-      export TFENV_DIR="${PWD}/${_arg#-chdir=}";
+      chdir="${_arg#-chdir=}";
+      log 'debug' "Found -chdir arg: ${chdir}";
+      export TFENV_DIR="${PWD}/$(realpath --relative-to="${PWD}" "$chdir")";
+      log 'debug' "Setting TFENV_DIR to: ${TFENV_DIR}";
     fi;
   done;
 

--- a/lib/tfenv-exec.sh
+++ b/lib/tfenv-exec.sh
@@ -2,12 +2,38 @@
 
 set -uo pipefail;
 
+function realpath-relative-to() {
+  # A basic implementation of GNU `realpath --relative-to=$1 $2`
+  # that can also be used on macOS.
+
+  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
+  readlink_f() {
+    local target_file="${1}";
+    local file_name;
+
+    while [ "${target_file}" != "" ]; do
+      cd "$(dirname "$target_file")" || early_death "Failed to 'cd \$(${target_file%/*})'";
+      file_name="${target_file##*/}" || early_death "Failed to '\"${target_file##*/}\"'";
+      target_file="$(readlink "${file_name}")";
+    done;
+
+    echo "$(pwd -P)/${file_name}";
+  };
+
+  local relative_to="$(readlink_f "${1}")";
+  local path="$(readlink_f "${2}")";
+
+  echo "${path#"${relative_to}/"}";
+  return 0;
+}
+export -f realpath-relative-to;
+
 function tfenv-exec() {
   for _arg in ${@:1}; do
     if [[ "${_arg}" == -chdir=* ]]; then
       chdir="${_arg#-chdir=}";
       log 'debug' "Found -chdir arg: ${chdir}";
-      export TFENV_DIR="${PWD}/$(realpath --relative-to="${PWD}" "$chdir")";
+      export TFENV_DIR="${PWD}/$(realpath-relative-to "${PWD}" "${chdir}")";
       log 'debug' "Setting TFENV_DIR to: ${TFENV_DIR}";
     fi;
   done;

--- a/lib/tfenv-exec.sh
+++ b/lib/tfenv-exec.sh
@@ -5,21 +5,6 @@ set -uo pipefail;
 function realpath-relative-to() {
   # A basic implementation of GNU `realpath --relative-to=$1 $2`
   # that can also be used on macOS.
-
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname "$target_file")" || early_death "Failed to 'cd \$(${target_file%/*})'";
-      file_name="${target_file##*/}" || early_death "Failed to '\"${target_file##*/}\"'";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   local relative_to="$(readlink_f "${1}")";
   local path="$(readlink_f "${2}")";
 

--- a/libexec/tfenv---version
+++ b/libexec/tfenv---version
@@ -21,20 +21,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-exec
+++ b/libexec/tfenv-exec
@@ -25,20 +25,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -11,20 +11,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-list
+++ b/libexec/tfenv-list
@@ -12,20 +12,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-list-remote
+++ b/libexec/tfenv-list-remote
@@ -12,20 +12,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -14,20 +14,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-pin
+++ b/libexec/tfenv-pin
@@ -12,20 +12,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-resolve-version
+++ b/libexec/tfenv-resolve-version
@@ -14,20 +14,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-uninstall
+++ b/libexec/tfenv-uninstall
@@ -12,20 +12,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -11,20 +11,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-version-file
+++ b/libexec/tfenv-version-file
@@ -14,20 +14,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -13,20 +13,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/test/run.sh
+++ b/test/run.sh
@@ -11,20 +11,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -11,20 +11,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/test/test_list.sh
+++ b/test/test_list.sh
@@ -12,20 +12,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/test/test_symlink.sh
+++ b/test/test_symlink.sh
@@ -12,20 +12,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -12,20 +12,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/test/test_use_latestallowed.sh
+++ b/test/test_use_latestallowed.sh
@@ -12,20 +12,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/test/test_use_minrequired.sh
+++ b/test/test_use_minrequired.sh
@@ -12,20 +12,6 @@ function early_death() {
 };
 
 if [ -z "${TFENV_ROOT:-""}" ]; then
-  # http://stackoverflow.com/questions/1055671/how-can-i-get-the-behavior-of-gnus-readlink-f-on-a-mac
-  readlink_f() {
-    local target_file="${1}";
-    local file_name;
-
-    while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
-      file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
-      target_file="$(readlink "${file_name}")";
-    done;
-
-    echo "$(pwd -P)/${file_name}";
-  };
-
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
   [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else

--- a/test/test_use_minrequired.sh
+++ b/test/test_use_minrequired.sh
@@ -121,7 +121,7 @@ echo 'min-required' > .terraform-version;
 cleanup || log 'error' 'Cleanup failed?!';
 
 
-log 'info' '### Install min-required with TFENV_AUTO_INSTALL & -chdir';
+log 'info' '### Install min-required with TFENV_AUTO_INSTALL & -chdir with rel path';
 
 minv='1.1.0';
 
@@ -133,6 +133,24 @@ echo 'min-required' > chdir-dir/.terraform-version
 
 (
   TFENV_AUTO_INSTALL=true terraform -chdir=chdir-dir version;
+  check_active_version "${minv}" chdir-dir;
+) || error_and_proceed 'Min required version from -chdir does not match';
+
+cleanup || log 'error' 'Cleanup failed?!';
+
+
+log 'info' '### Install min-required with TFENV_AUTO_INSTALL & -chdir with abs path';
+
+minv='1.2.3';
+
+mkdir -p chdir-dir
+echo "terraform {
+  required_version = \">=${minv}\"
+}" >> chdir-dir/min_required.tf;
+echo 'min-required' > chdir-dir/.terraform-version
+
+(
+  TFENV_AUTO_INSTALL=true terraform -chdir="${PWD}/chdir-dir" version;
   check_active_version "${minv}" chdir-dir;
 ) || error_and_proceed 'Min required version from -chdir does not match';
 


### PR DESCRIPTION
In the course of fixing #355's use of `realpath --relative-to` for macOS, I tried to use `readlink --canonicalize`/`-f` which had a similar problem, and through that noticed the extensive extant use of a `readlink_f` function to achieve that functionality. The same function is currently replicated 23 times through the repo.

In the interest of readability, maintainability etc., this PR refactors that to the common helpers.sh, exporting it for use everywhere without redefinition.

#353 also revealed a bug in the implementation I copied again, which I subsequently fixed in that instance. That's reproduced here too (and thus for all uses of the function) in 1784a4f0d8b96d23b70f472197a952db575d1e05.

(This is based on top of #355, since that PR adds another instance of this function. I'll rebase this once that's merged - please consider this a draft until then.)