### PR TITLE
Add env variable to skip listing remote versions before installation

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -73,8 +73,10 @@ declare regex="${resolved##*\:}";
 
 log 'debug' "Processing install for version ${version}, using regex ${regex}";
 
-remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)";
-[ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
+if [ "${TFENV_SKIP_LIST_REMOTE:-0}" -eq 0 ]; then
+  remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)";
+  [ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
+fi
 
 dst_path="${TFENV_CONFIG_DIR}/versions/${version}";
 if [ -f "${dst_path}/terraform" ]; then


### PR DESCRIPTION
This is a genuine use case where you're using artifactory virtual repository like structure. Artifactory acts as a proxy for Hashicorp repository and lists only the versions downloaded beforehand. This causes tfenv to fail stating that the version doesn't exist in the remote repository when you want to download a version not in the cache.