### PR TITLE
Fix incorrect command name

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ $ TFENV_AUTO_INSTALL=false terraform plan
 ```
 
 ```console
-$ terraform use <version that is not yet installed>
+$ tfenv use <version that is not yet installed>
 ```
 
 ##### `TFENV_CURL_OUTPUT`


### PR DESCRIPTION
In the section `TFENV_AUTO_INSTALL` in `README.md`, `$ terraform use <version that is not yet installed>` is supposed to be `$ tfenv use <version that is not yet installed>`. 

Fix the incorrect command name