### PR TITLE
fix: Underscores are needed for Cygwin-like tools

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -89,10 +89,10 @@ case "$(uname -s)" in
   MINGW64*)
     kernel="windows";
     ;;
-  MSYSNT*)
+  MSYS_NT*)
     kernel="windows";
     ;;
-  CYGWINNT*)
+  CYGWIN_NT*)
     kernel="windows";
     ;;
   FreeBSD*)

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -89,10 +89,10 @@ case "$(uname -s)" in
   MINGW64*)
     kernel="windows";
     ;;
-  MSYS_NT*)
+  MSYS*NT*)
     kernel="windows";
     ;;
-  CYGWIN_NT*)
+  CYGWIN*NT*)
     kernel="windows";
     ;;
   FreeBSD*)


### PR DESCRIPTION
Fixes #381 