### PR TITLE
Fix darwin arch selection logic

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -124,8 +124,7 @@ case "$(uname -m)" in
       ;;
       "darwin")
         # No Apple Silicon builds before 1.0.2
-        if [[ "${version}" =~ 0\..+$ || "${version}" =~ 1\.0\.0|1$
-        ]]; then
+        if [[ "${version}" =~ ^0\. || "${version}" =~ ^1\.0\.[01]$ ]]; then
           TFENV_ARCH="${TFENV_ARCH:-amd64}";
         else
           TFENV_ARCH="${TFENV_ARCH:-arm64}";


### PR DESCRIPTION
Fixes #384 -- This corrects the regex to choose amd64 for versions < 1.0.2

Tested as follows:

1. Created a script to test the logic in isolation:

```sh
#!/usr/bin/env bash

while read version; do
    if [[ "${version}" =~ ^0\. || "${version}" =~ ^1\.0\.[01]$ ]]; then
      echo "amd64  $version"
    else
      echo "ARM64  $version"
    fi;
done
```

2. Piped `tfenv list-remote` to this script to test all current versions:

```
tfenv list-remote | ~/version-logic.sh
```

3. Verified that the output switched from amd64 to arm64 at the expected version (truncated for brevity):

```
ARM64  1.0.4
ARM64  1.0.3
ARM64  1.0.2
amd64  1.0.1
amd64  1.0.0
amd64  0.15.5
```

4. Temporarily patched my local installed `libexec/tfenv-install` with no `TFENV_ARCH` set in my environment and tested some relevant cases (note the arch in the download URL):

```
% tfenv install 1.0.1
Installing Terraform v1.0.1
Downloading release tarball from https://releases.hashicorp.com/terraform/1.0.1/terraform_1.0.1_darwin_amd64.zip
...
Installation of terraform v1.0.1 successful. To make this your default version, run 'tfenv use 1.0.1'

% tfenv install 1.0.2
Installing Terraform v1.0.2
Downloading release tarball from https://releases.hashicorp.com/terraform/1.0.2/terraform_1.0.2_darwin_arm64.zip
...
Installation of terraform v1.0.2 successful. To make this your default version, run 'tfenv use 1.0.2'

% tfenv install 1.0.10
Installing Terraform v1.0.10
Downloading release tarball from https://releases.hashicorp.com/terraform/1.0.10/terraform_1.0.10_darwin_arm64.zip
...
Installation of terraform v1.0.10 successful. To make this your default version, run 'tfenv use 1.0.10'

% tfenv install 1.0.11
Installing Terraform v1.0.11
Downloading release tarball from https://releases.hashicorp.com/terraform/1.0.11/terraform_1.0.11_darwin_arm64.zip
...
Installation of terraform v1.0.11 successful. To make this your default version, run 'tfenv use 1.0.11'
```