### PR TITLE
Fix darwin arch regex forces amd64 for some versions with arm64 available

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -124,7 +124,7 @@ case "$(uname -m)" in
       ;;
       "darwin")
         # No Apple Silicon builds before 1.0.2
-        if [[ "${version}" =~ 0\..+$ || "${version}" =~ 1\.0\.0|1$
+        if [[ "${version}" =~ ^0\.[0-9]+\.[0-9]+$ || "${version}" =~ ^1\.0\.[0-1]$
         ]]; then
           TFENV_ARCH="${TFENV_ARCH:-amd64}";
         else

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -124,7 +124,7 @@ case "$(uname -m)" in
       ;;
       "darwin")
         # No Apple Silicon builds before 1.0.2
-        if [[ "${version}" =~ ^0\.[0-9]+\.[0-9]+$ || "${version}" =~ ^1\.0\.[0-1]$
+        if [[ "${version}" =~ ^0\.[0-9]+\.[0-9]+ || "${version}" =~ ^1\.0\.[0-1]$
         ]]; then
           TFENV_ARCH="${TFENV_ARCH:-amd64}";
         else


### PR DESCRIPTION
The regexes [currently in master](https://github.com/tfutils/tfenv/blob/1ccfddb22005b34eacaf06a9c33f58f14e816ec9/libexec/tfenv-install#L127) (from #351, but not yet released) fix all cases where tfenv cannot install because arm64 is unavailable. However, they occasionally force tfenv to install the amd64 binary for some of the >1.0.2 versions.

First, `0\..+$` matches any value containing `0.`, including versions with arm64 builds (e.g. `1.0.3`).

The `1\.0\.0|1$` regex would also match `1.5.0-beta1` (but not `1.5.0-beta2`), `1.10.1`, or anything else that starts with `1.`, contains a `0`, and then ends with a `1`. I believe this regex was intended to be written as `^(1\.0\.0|1)$` or `^1\.0\.0$|^1$`. It seems more readable to just use `^1\.0\.[0-1]$`. I couldn't find any `-beta` or `-rc` releases of `1.0.0` or `1.0.1`, so this should be safe.

You can test this behavior with some bash
```bash
echo "tfenv 3.0.0"
for version in "0.." "0.6.6" "0.10.0" "0.10.0-beta2" "0.11.0-rc1" "0.11.15"  "0.12.31" "1.0.0" "1.0.1" "1.0.2" "1.0.3" "1.2.3" "1.5.0-beta1" "1.20.1" ; do
  if [[ "${version}" =~ 0\..+$ || "${version}" =~ 1\.0\.0|1$
  ]]; then
    echo "${version} amd64"
  else
    echo "${version}"
  fi;
done
```
```
tfenv 3.0.0
0.. amd64
0.6.6 amd64
0.10.0 amd64
0.10.0-beta2 amd64
0.11.0-rc1 amd64
0.11.15 amd64
0.12.31 amd64
1.0.0 amd64
1.0.1 amd64
1.0.2 amd64
1.0.3 amd64
1.2.3
1.5.0-beta1 amd64
1.20.1 amd64
```

---
The new regex seems to fix all of these cases:
```bash
echo "PR Version"
for version in "0.." "0.6.6" "0.10.0" "0.10.0-beta2" "0.11.0-rc1" "0.11.15"  "0.12.31" "1.0.0" "1.0.1" "1.0.2" "1.0.3" "1.2.3" "1.5.0-beta1" "1.20.1" ; do
  if [[ "${version}" =~ ^0\.[0-9]+\.[0-9]+ || "${version}" =~ ^1\.0\.[0-1]$
  ]]; then
    echo "${version} amd64"
  else
    echo "${version}"
  fi;
done
```
```
PR Version
0..
0.6.6 amd64
0.10.0 amd64
0.10.0-beta2 amd64
0.11.0-rc1 amd64
0.11.15 amd64
0.12.31 amd64
1.0.0 amd64
1.0.1 amd64
1.0.2
1.0.3
1.2.3
1.5.0-beta1
1.20.1
```

You can also test this against all versions of terraform tfenv sees:
```bash
for version in $(tfenv list-remote) ; do
  if [[ "${version}" =~ ^0\.[0-9]+\.[0-9]+ || "${version}" =~ ^1\.0\.[0-1]$
  ]]; then
    echo "${version} amd64"
  else
    echo "${version}"
  fi;
done
```
They all look correct to me
<details>

```
PR Version against all remotes
1.5.1
1.5.0
1.5.0-rc2
1.5.0-rc1
1.5.0-beta2
1.5.0-beta1
1.5.0-alpha20230504
1.5.0-alpha20230405
1.4.6
1.4.5
1.4.4
1.4.3
1.4.2
1.4.1
1.4.0
1.4.0-rc1
1.4.0-beta2
1.4.0-beta1
1.4.0-alpha20221207
1.4.0-alpha20221109
1.3.9
1.3.8
1.3.7
1.3.6
1.3.5
1.3.4
1.3.3
1.3.2
1.3.1
1.3.0
1.3.0-rc1
1.3.0-beta1
1.3.0-alpha20220817
1.3.0-alpha20220803
1.3.0-alpha20220706
1.3.0-alpha20220622
1.3.0-alpha20220608
1.2.9
1.2.8
1.2.7
1.2.6
1.2.5
1.2.4
1.2.3
1.2.2
1.2.1
1.2.0
1.2.0-rc2
1.2.0-rc1
1.2.0-beta1
1.2.0-alpha20220413
1.2.0-alpha-20220328
1.1.9
1.1.8
1.1.7
1.1.6
1.1.5
1.1.4
1.1.3
1.1.2
1.1.1
1.1.0
1.1.0-rc1
1.1.0-beta2
1.1.0-beta1
1.1.0-alpha20211029
1.1.0-alpha20211020
1.1.0-alpha20211006
1.1.0-alpha20210922
1.1.0-alpha20210908
1.1.0-alpha20210811
1.1.0-alpha20210728
1.1.0-alpha20210714
1.1.0-alpha20210630
1.1.0-alpha20210616
1.0.11
1.0.10
1.0.9
1.0.8
1.0.7
1.0.6
1.0.5
1.0.4
1.0.3
1.0.2
1.0.1 amd64
1.0.0 amd64
0.15.5 amd64
0.15.4 amd64
0.15.3 amd64
0.15.2 amd64
0.15.1 amd64
0.15.0 amd64
0.15.0-rc2 amd64
0.15.0-rc1 amd64
0.15.0-beta2 amd64
0.15.0-beta1 amd64
0.15.0-alpha20210210 amd64
0.15.0-alpha20210127 amd64
0.15.0-alpha20210107 amd64
0.14.11 amd64
0.14.10 amd64
0.14.9 amd64
0.14.8 amd64
0.14.7 amd64
0.14.6 amd64
0.14.5 amd64
0.14.4 amd64
0.14.3 amd64
0.14.2 amd64
0.14.1 amd64
0.14.0 amd64
0.14.0-rc1 amd64
0.14.0-beta2 amd64
0.14.0-beta1 amd64
0.14.0-alpha20201007 amd64
0.14.0-alpha20200923 amd64
0.14.0-alpha20200910 amd64
0.13.7 amd64
0.13.6 amd64
0.13.5 amd64
0.13.4 amd64
0.13.3 amd64
0.13.2 amd64
0.13.1 amd64
0.13.0 amd64
0.13.0-rc1 amd64
0.13.0-beta3 amd64
0.13.0-beta2 amd64
0.13.0-beta1 amd64
0.12.31 amd64
0.12.30 amd64
0.12.29 amd64
0.12.28 amd64
0.12.27 amd64
0.12.26 amd64
0.12.25 amd64
0.12.24 amd64
0.12.23 amd64
0.12.22 amd64
0.12.21 amd64
0.12.20 amd64
0.12.19 amd64
0.12.18 amd64
0.12.17 amd64
0.12.16 amd64
0.12.15 amd64
0.12.14 amd64
0.12.13 amd64
0.12.12 amd64
0.12.11 amd64
0.12.10 amd64
0.12.9 amd64
0.12.8 amd64
0.12.7 amd64
0.12.6 amd64
0.12.5 amd64
0.12.4 amd64
0.12.3 amd64
0.12.2 amd64
0.12.1 amd64
0.12.0 amd64
0.12.0-rc1 amd64
0.12.0-beta2 amd64
0.12.0-beta1 amd64
0.12.0-alpha4 amd64
0.12.0-alpha3 amd64
0.12.0-alpha2 amd64
0.12.0-alpha1 amd64
0.11.15 amd64
0.11.15-oci amd64
0.11.14 amd64
0.11.13 amd64
0.11.12 amd64
0.11.12-beta1 amd64
0.11.11 amd64
0.11.10 amd64
0.11.9 amd64
0.11.9-beta1 amd64
0.11.8 amd64
0.11.7 amd64
0.11.6 amd64
0.11.5 amd64
0.11.4 amd64
0.11.3 amd64
0.11.2 amd64
0.11.1 amd64
0.11.0 amd64
0.11.0-rc1 amd64
0.11.0-beta1 amd64
0.10.8 amd64
0.10.7 amd64
0.10.6 amd64
0.10.5 amd64
0.10.4 amd64
0.10.3 amd64
0.10.2 amd64
0.10.1 amd64
0.10.0 amd64
0.10.0-rc1 amd64
0.10.0-beta2 amd64
0.10.0-beta1 amd64
0.9.11 amd64
0.9.10 amd64
0.9.9 amd64
0.9.8 amd64
0.9.7 amd64
0.9.6 amd64
0.9.5 amd64
0.9.4 amd64
0.9.3 amd64
0.9.2 amd64
0.9.1 amd64
0.9.0 amd64
0.8.8 amd64
0.8.7 amd64
0.8.6 amd64
0.8.5 amd64
0.8.4 amd64
0.8.3 amd64
0.8.2 amd64
0.8.1 amd64
0.8.0 amd64
0.7.13 amd64
0.7.12 amd64
0.7.11 amd64
0.7.10 amd64
0.7.9 amd64
0.7.8 amd64
0.7.7 amd64
0.7.6 amd64
0.7.5 amd64
0.7.4 amd64
0.7.3 amd64
0.7.2 amd64
0.7.1 amd64
0.7.0 amd64
0.6.16 amd64
0.6.15 amd64
0.6.14 amd64
0.6.13 amd64
0.6.12 amd64
0.6.11 amd64
0.6.10 amd64
0.6.9 amd64
0.6.8 amd64
0.6.7 amd64
0.6.6 amd64
0.6.5 amd64
0.6.4 amd64
0.6.3 amd64
0.6.2 amd64
0.6.1 amd64
0.6.0 amd64
0.5.3 amd64
0.5.1 amd64
0.5.0 amd64
0.4.2 amd64
0.4.1 amd64
0.4.0 amd64
0.3.7 amd64
0.3.6 amd64
0.3.5 amd64
0.3.1 amd64
0.3.0 amd64
0.2.2 amd64
0.2.1 amd64
0.2.0 amd64
0.1.1 amd64
0.1.0 amd64
```

</details>