### PR TITLE
Properly handle paths with whitespace

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -140,8 +140,8 @@ function error_and_proceed() {
 export -f error_and_proceed;
 
 function check_dependencies() {
-  if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
-    if ! [ $(which ggrep) ]; then
+  if [[ $(uname) == 'Darwin' ]] && [ "$(which brew)" ]; then
+    if ! [ "$(which ggrep)" ]; then
       log 'error' 'A metaphysical dichotomy has caused this unit to overload and shut down. GNU Grep is a requirement and your Mac does not have it. Consider "brew install grep"';
     fi;
 

--- a/lib/tfenv-min-required.sh
+++ b/lib/tfenv-min-required.sh
@@ -5,7 +5,7 @@ set -uo pipefail;
 function tfenv-min-required() {
   local path="${1:-${TFENV_DIR:-.}}";
 
-  local versions="$( echo $(cat ${path}/{*.tf,*.tf.json} 2>/dev/null | grep -Eh '^\s*[^#]*\s*required_version') | grep -o '[~=!<>]\{0,2\}\s*\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
+  local versions="$( echo $(cat "${path}"/{*.tf,*.tf.json} 2>/dev/null | grep -Eh '^\s*[^#]*\s*required_version') | grep -o '[~=!<>]\{0,2\}\s*\([0-9]\+\.\?\)\{2,3\}\(-[a-z]\+[0-9]\+\)\?')";
 
   if [[ "${versions}" =~ ([~=!<>]{0,2}[[:blank:]]*)([0-9]+[0-9.]+)[^0-9]*(-[a-z]+[0-9]+)? ]]; then
     qualifier="${BASH_REMATCH[1]}";
@@ -13,7 +13,7 @@ function tfenv-min-required() {
     if [[ "${qualifier}" =~ ^!= ]]; then
       log 'debug' "required_version is a negation - we cannot guess the desired one, skipping.";
     else
-      local min_required_file="$(grep -Hn required_version ${path}/{*.tf,*.tf.json} 2>/dev/null | xargs)";
+      local min_required_file="$(grep -Hn required_version "${path}"/{*.tf,*.tf.json} 2>/dev/null | xargs)";
 
       # Probably not an advisable way to choose a terraform version,
       # but this is the way this functionality works in terraform:

--- a/libexec/tfenv---version
+++ b/libexec/tfenv---version
@@ -27,7 +27,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;
@@ -74,7 +74,7 @@ version="$(awk '/^##/{ print $2; exit}' "${TFENV_ROOT}/CHANGELOG.md")" \
   || log 'error' 'Failed to scrape version from CHANGELOG.md';
 
 git_revision="";
-if cd "$(dirname ${0})" 2>/dev/null && git remote -v 2>/dev/null | grep -q tfenv; then
+if cd "$(dirname "${0}")" 2>/dev/null && git remote -v 2>/dev/null | grep -q tfenv; then
   log 'debug' 'Git configuration found. Overriding CHANGELOG version from git revision...';
   git_revision="$(git describe --tags HEAD 2>/dev/null || true)";
   log 'debug' "Stripping git revision string from ${git_revision}";

--- a/libexec/tfenv-exec
+++ b/libexec/tfenv-exec
@@ -31,7 +31,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -17,7 +17,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tfenv-list
+++ b/libexec/tfenv-list
@@ -18,7 +18,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tfenv-min-required
+++ b/libexec/tfenv-min-required
@@ -20,7 +20,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tfenv-pin
+++ b/libexec/tfenv-pin
@@ -18,7 +18,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tfenv-resolve-version
+++ b/libexec/tfenv-resolve-version
@@ -20,7 +20,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tfenv-uninstall
+++ b/libexec/tfenv-uninstall
@@ -18,7 +18,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -17,7 +17,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tfenv-version-file
+++ b/libexec/tfenv-version-file
@@ -20,7 +20,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/libexec/tfenv-version-name
+++ b/libexec/tfenv-version-name
@@ -19,7 +19,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/test/install_deps.sh
+++ b/test/install_deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -uo pipefail;
 
-if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
+if [[ $(uname) == 'Darwin' ]] && [ "$(which brew)" ]; then
   brew install grep;
 fi;

--- a/test/run.sh
+++ b/test/run.sh
@@ -17,7 +17,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -17,7 +17,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/test/test_list.sh
+++ b/test/test_list.sh
@@ -18,7 +18,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/test/test_symlink.sh
+++ b/test/test_symlink.sh
@@ -18,7 +18,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -18,7 +18,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/test/test_use_latestallowed.sh
+++ b/test/test_use_latestallowed.sh
@@ -18,7 +18,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;

--- a/test/test_use_minrequired.sh
+++ b/test/test_use_minrequired.sh
@@ -18,7 +18,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
     local file_name;
 
     while [ "${target_file}" != "" ]; do
-      cd "$(dirname ${target_file})" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
+      cd "$(dirname "${target_file}")" || early_death "Failed to 'cd \$(dirname ${target_file})' while trying to determine TFENV_ROOT";
       file_name="$(basename "${target_file}")" || early_death "Failed to 'basename \"${target_file}\"' while trying to determine TFENV_ROOT";
       target_file="$(readlink "${file_name}")";
     done;


### PR DESCRIPTION
Before, `tfenv` would exit with a mysterious error if its file location included any whitespace characters. Missing quotes were added to prevent word splitting, which causes this error.