### PR TITLE
Add EditorConfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Dockerfile]
+indent_size = 4


### PR DESCRIPTION
When working on #424, I noticed my editor didn't use the correct formatting settings. I added an [EditorConfig](https://editorconfig.org) to fix this and so other contributors can avoid this issue.