### PR TITLE
Fix various ShellCheck violations

### DIFF
--- a/lib/bashlog.sh
+++ b/lib/bashlog.sh
@@ -40,7 +40,7 @@ function log() {
 
   shift 1;
 
-  local line="$@";
+  local line="$*";
 
   # RFC 5424
   #

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -72,7 +72,7 @@ function curlw () {
     TLS_OPT="";
   fi;
 
-  if [[ ! -z "${TFENV_NETRC_PATH:-""}" ]]; then
+  if [[ -n "${TFENV_NETRC_PATH:-""}" ]]; then
     NETRC_OPT="--netrc-file ${TFENV_NETRC_PATH}";
   else
     NETRC_OPT="";
@@ -104,7 +104,7 @@ export -f check_active_version;
 function check_installed_version() {
   local v="${1}";
   local bin="${TFENV_CONFIG_DIR}/versions/${v}/terraform";
-  [ -n "$(${bin} version | grep -E "^Terraform v${v}((-dev)|( \([a-f0-9]+\)))?$")" ];
+  "${bin}" version | grep -qE "^Terraform v${v}((-dev)|( \([a-f0-9]+\)))?$"
 };
 export -f check_installed_version;
 
@@ -117,18 +117,17 @@ export -f check_default_version;
 
 function cleanup() {
   log 'info' 'Performing cleanup';
-  local pwd="$(pwd)";
-  log 'debug' "Deleting ${pwd}/version";
+  log 'debug' "Deleting ${PWD}/version";
   rm -rf ./version;
-  log 'debug' "Deleting ${pwd}/versions";
+  log 'debug' "Deleting ${PWD}/versions";
   rm -rf ./versions;
-  log 'debug' "Deleting ${pwd}/.terraform-version";
+  log 'debug' "Deleting ${PWD}/.terraform-version";
   rm -rf ./.terraform-version;
-  log 'debug' "Deleting ${pwd}/latest_allowed.tf";
+  log 'debug' "Deleting ${PWD}/latest_allowed.tf";
   rm -rf ./latest_allowed.tf;
-  log 'debug' "Deleting ${pwd}/min_required.tf";
+  log 'debug' "Deleting ${PWD}/min_required.tf";
   rm -rf ./min_required.tf;
-  log 'debug' "Deleting ${pwd}/chdir-dir";
+  log 'debug' "Deleting ${PWD}/chdir-dir";
   rm -rf ./chdir-dir;
 };
 export -f cleanup;

--- a/libexec/tfenv-help
+++ b/libexec/tfenv-help
@@ -2,7 +2,7 @@
 
 set -uo pipefail;
 
-echo 'Usage: tfenv <command> [<options>]
+echo "Usage: tfenv <command> [<options>]
 
 Commands:
    install       Install a specific version of Terraform
@@ -13,6 +13,6 @@ Commands:
    version-name  Print current version
    init          Update environment to use 'tfenv' correctly.
    pin           Write the current active version to ./.terraform-version
-';
+";
 
 exit 0;

--- a/libexec/tfenv-resolve-version
+++ b/libexec/tfenv-resolve-version
@@ -71,7 +71,7 @@ declare version_requested version regex min_required version_file;
 
 declare arg="${1:-""}";
 
-if [ -z "${arg}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
+if [ -z "${arg}" ] && [ -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
   version_file="$(tfenv-version-file)";
   log 'debug' "Version File: ${version_file}";
 
@@ -91,7 +91,7 @@ if [ -z "${arg}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
       version_requested='latest';
     fi;
 
-  else 
+  else
     log 'debug' "Version File is the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version) but it doesn't exist";
     log 'debug' 'No version requested on the command line or in the version file search path. Installing "latest"';
     version_requested='latest';

--- a/libexec/tfenv-uninstall
+++ b/libexec/tfenv-uninstall
@@ -64,7 +64,7 @@ done;
 declare version_requested version regex;
 declare arg="${1:-""}";
 
-if [ -z "${arg:-""}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
+if [ -z "${arg:-""}" ] && [ -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
   version_file="$(tfenv-version-file)";
   log 'debug' "Version File: ${version_file}";
   if [ "${version_file}" != "${TFENV_CONFIG_DIR}/version" ]; then

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -72,7 +72,7 @@ declare version_source_suffix="";
 declare requested="${requested_arg}";
 declare loaded_version_file="$(tfenv-version-file)";
 
-if [ -z "${requested_arg}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
+if [ -z "${requested_arg}" ] && [ -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
   version_source_suffix=" (set by ${loaded_version_file})";
 
   if [ -f "${loaded_version_file}" ]; then

--- a/test/run.sh
+++ b/test/run.sh
@@ -26,7 +26,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
   };
 
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
+  [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else
   TFENV_ROOT="${TFENV_ROOT%/}";
 fi;
@@ -51,7 +51,7 @@ export PATH="${TFENV_ROOT}/bin:${PATH}";
 
 errors=();
 if [ "${#}" -ne 0 ]; then
-  targets="$@";
+  targets="$*";
 else
   targets="$(\ls "$(dirname "${0}")" | grep 'test_')";
 fi;

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -133,7 +133,7 @@ declare desc kv k v test_num;
 
 for ((test_iter=0; test_iter<${tests_count}; ++test_iter )) ; do
   cleanup || log 'error' 'Cleanup failed?!';
-  test_num=$((test_iter + 1)); 
+  test_num=$((test_iter + 1));
   desc=${tests__desc[${test_iter}]};
   kv="${tests__kv[${test_iter}]}";
   v="${kv%,*}";
@@ -146,7 +146,7 @@ done;
 
 for ((test_iter=0; test_iter<${tests_count}; ++test_iter )) ; do
   cleanup || log 'error' 'Cleanup failed?!';
-  test_num=$((test_iter + 1)); 
+  test_num=$((test_iter + 1));
   desc=${tests__desc[${test_iter}]};
   kv="${tests__kv[${test_iter}]}";
   v="${kv%,*}";
@@ -161,7 +161,7 @@ done;
 
 for ((test_iter=0; test_iter<${tests_count}; ++test_iter )) ; do
   cleanup || log 'error' 'Cleanup failed?!';
-  test_num=$((test_iter + 1)); 
+  test_num=$((test_iter + 1));
   desc=${tests__desc[${test_iter}]};
   kv="${tests__kv[${test_iter}]}";
   v="${kv%,*}";

--- a/test/test_list.sh
+++ b/test/test_list.sh
@@ -27,7 +27,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
   };
 
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
+  [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else
   TFENV_ROOT="${TFENV_ROOT%/}";
 fi;

--- a/test/test_symlink.sh
+++ b/test/test_symlink.sh
@@ -27,7 +27,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
   };
 
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
+  [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else
   TFENV_ROOT="${TFENV_ROOT%/}";
 fi;

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -27,7 +27,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
   };
 
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
+  [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else
   TFENV_ROOT="${TFENV_ROOT%/}";
 fi;

--- a/test/test_use_latestallowed.sh
+++ b/test/test_use_latestallowed.sh
@@ -27,7 +27,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
   };
 
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
+  [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else
   TFENV_ROOT="${TFENV_ROOT%/}";
 fi;

--- a/test/test_use_minrequired.sh
+++ b/test/test_use_minrequired.sh
@@ -27,7 +27,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
   };
 
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
+  [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else
   TFENV_ROOT="${TFENV_ROOT%/}";
 fi;


### PR DESCRIPTION
This fixes various ShellCheck errors, such as:

- Prefer `&&` [instead of `-a`](https://www.shellcheck.net/wiki/SC2166)
- `[ -n` must be [used with a quoted argument](https://www.shellcheck.net/wiki/SC2070)
- Prefer `-n` [over `! -z`](https://www.shellcheck.net/wiki/SC2236)
- Avoiding [assigning an array to a string](https://www.shellcheck.net/wiki/SC2124)
- [Prefer `grep -q`](https://www.shellcheck.net/wiki/SC2143)

This PR is similar to #424, but addresses less-severe issues.