### PR TITLE
Cope with different line endings in .terraform-version

### DIFF
--- a/lib/tfenv-version-name.sh
+++ b/lib/tfenv-version-name.sh
@@ -10,7 +10,7 @@ function tfenv-version-name() {
       && log 'debug' "TFENV_VERSION_FILE retrieved from tfenv-version-file: ${TFENV_VERSION_FILE}" \
       || log 'error' 'Failed to retrieve TFENV_VERSION_FILE from tfenv-version-file';
 
-    TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" || true)" \
+    TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" || true | tr -d '\r')" \
       && log 'debug' "TFENV_VERSION specified in TFENV_VERSION_FILE: ${TFENV_VERSION}";
 
     TFENV_VERSION_SOURCE="${TFENV_VERSION_FILE}";

--- a/libexec/tfenv-resolve-version
+++ b/libexec/tfenv-resolve-version
@@ -77,12 +77,12 @@ if [ -z "${arg}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
 
   if [ "${version_file}" != "${TFENV_CONFIG_DIR}/version" ]; then
     log 'debug' "Version File (${version_file}) is not the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version)";
-    version_requested="$(cat "${version_file}")" \
+    version_requested="$(cat "${version_file}" | tr -d '\r')" \
       || log 'error' "Failed to open ${version_file}";
 
   elif [ -f "${version_file}" ]; then
     log 'debug' "Version File is the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version)";
-    version_requested="$(cat "${version_file}")" \
+    version_requested="$(cat "${version_file}" | tr -d '\r')" \
       || log 'error' "Failed to open ${version_file}";
 
     # Absolute fallback


### PR DESCRIPTION
Use `tr` to strip carriage returns from this file as it can cause failures in repositories with CRLF.

Fixes #243 