### PR TITLE
Don't assume brew is available in the system

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -147,13 +147,16 @@ function error_and_proceed() {
 export -f error_and_proceed;
 
 function check_dependencies() {
-  if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
-    if ! [ $(which ggrep) ]; then
-      log 'error' 'A metaphysical dichotomy has caused this unit to overload and shut down. GNU Grep is a requirement and your Mac does not have it. Consider "brew install grep"';
+  if [[ $(uname) == 'Darwin' ]]; then
+    # If installed through brew, it will be available as `ggrep`, so we alias it to `grep`
+    if command -v ggrep >/dev/null 2>&1; then
+      shopt -s expand_aliases;
+      alias grep=ggrep;
     fi;
 
-    shopt -s expand_aliases;
-    alias grep=ggrep;
+    if ! grep --version 2>&1 | grep -q "GNU grep"; then
+      log 'error' 'GNU Grep is a requirement and your Mac does not have it. Consider installing it with `brew install grep` or `nix profile install nixpkgs#gnugrep`';
+    fi;
   fi;
 };
 export -f check_dependencies;

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -152,6 +152,10 @@ function check_dependencies() {
     if command -v ggrep >/dev/null 2>&1; then
       shopt -s expand_aliases;
       alias grep=ggrep;
+
+      # The alias can't be defined and used in the same parsing unit. But
+      # since we know the correct package is installed, we can exit early.
+      return;
     fi;
 
     if ! grep --version 2>&1 | grep -q "GNU grep"; then

--- a/test/install_deps.sh
+++ b/test/install_deps.sh
@@ -3,4 +3,7 @@ set -uo pipefail;
 
 if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
   brew install grep;
+  if [[ -n ${GITHUB_PATH+x} ]]; then
+    echo "/opt/homebrew/opt/grep/libexec/gnubin" >> $GITHUB_PATH
+  fi
 fi;


### PR DESCRIPTION
I'm working on a project that uses nix as a package manager through a flake file. I can add tfenv through a custom derivation, which can include the required gnugrep dependency in the definition.

But the project assumes that the GNU version would be installed with Homebrew, which might not be installed at all.

Since all we care about is that GNU grep is available, we should use `grep --version` instead.