### PR TITLE
Tfenv skip remote check

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ functionality will be restored.
 TFENV_REVERSE_REMOTE=1 tfenv list-remote
 ```
 
+##### `TFENV_SKIP_LIST_REMOTE`
+
+Integer (Default: 0)
+
+When using a custom remote, such as Artifactory, lazy caching may be used meaning the versions
+returned by the remote aren't the full list available (more can be pulled on demand). This option 
+disables the pre-install validation and will blindly pull the requested version from the remote.
+
 ##### `TFENV_CONFIG_DIR`
 
 Path (Default: `$TFENV_ROOT`)

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ tfenv install
 ```
 
 The `trust-tfenv` directive means that verification uses a copy of the
-Hashicorp OpenPGP key found in the tfenv repository.  Skipping that directive
+Hashicorp OpenPGP key found in the tfenv repository. Skipping that directive
 means that the Hashicorp key must be in the existing default trusted keys.
 Use the file `${TFENV_INSTALL_DIR}/use-gnupg` to instead invoke the full `gpg` tool and
 see web-of-trust status; beware that a lack of trust path will not cause a
@@ -231,13 +231,19 @@ functionality will be restored.
 TFENV_REVERSE_REMOTE=1 tfenv list-remote
 ```
 
-##### `TFENV_SKIP_LIST_REMOTE`
+##### `TFENV_SKIP_REMOTE_CHECK`
 
 Integer (Default: 0)
 
 When using a custom remote, such as Artifactory, lazy caching may be used meaning the versions
 returned by the remote aren't the full list available (more can be pulled on demand). This option 
-disables the pre-install validation and will blindly pull the requested version from the remote.
+disables the pre-install validation and will blindly pull the requested version from the remote. When
+using `latest` as the specified version, this will still rely on the latest version returned from the
+configured remote.
+
+```console
+TFENV_SKIP_REMOTE_CHECK=1 tfenv install 1.14.5
+```
 
 ##### `TFENV_CONFIG_DIR`
 

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -73,8 +73,10 @@ declare regex="${resolved##*\:}";
 
 log 'debug' "Processing install for version ${version}, using regex ${regex}";
 
-remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)";
-[ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
+if [ "${TFENV_SKIP_REMOTE_CHECK:-0}" -eq 0 ]; then
+  remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)";
+  [ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
+fi;
 
 dst_path="${TFENV_CONFIG_DIR}/versions/${version}";
 if [ -f "${dst_path}/terraform" ]; then


### PR DESCRIPTION
Adds the ability to skip remote list validation when installing from a repository with pull-through caching