### PR TITLE
Fix operator precedence bug and unbound variable in tfenv-version-name.sh

### DIFF
--- a/lib/tfenv-version-name.sh
+++ b/lib/tfenv-version-name.sh
@@ -10,7 +10,7 @@ function tfenv-version-name() {
       && log 'debug' "TFENV_VERSION_FILE retrieved from tfenv-version-file: ${TFENV_VERSION_FILE}" \
       || log 'error' 'Failed to retrieve TFENV_VERSION_FILE from tfenv-version-file';
 
-    TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" || true | tr -d '\r')" \
+    TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" | tr -d '\r' || true)" \
       && log 'debug' "TFENV_VERSION specified in TFENV_VERSION_FILE: ${TFENV_VERSION}";
 
     TFENV_VERSION_SOURCE="${TFENV_VERSION_FILE}";
@@ -77,7 +77,7 @@ function tfenv-version-name() {
             TFENV_VERSION="${local_version}";
           fi;
       else
-        log 'error' "No versions matching '${requested}' found in remote";
+        log 'error' "No versions matching '${TFENV_VERSION}' found in remote";
       fi;
     else
       if [[ -n "${local_version}" ]]; then


### PR DESCRIPTION
## Summary

Two bugs fixed in `lib/tfenv-version-name.sh`:

### 1. Shell operator precedence bug (line 13) — Fixes #431, #447

**Before:**
```bash
TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" || true | tr -d '\r')"
```
Due to shell precedence, `||` binds `cat` to `true`, making the pipeline `cat ... || (true | tr ...)`. The `tr -d '\r'` only runs on the failure path. When `cat` succeeds (the normal case), carriage returns are never stripped.

**After:**
```bash
TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" | tr -d '\r' || true)"
```
`tr` is now always in the pipeline. The `|| true` ensures the overall command does not fail if the file is missing.

This fixes the root cause of #431 (trailing whitespace breaking version resolution) and #447 (WSL/Windows carriage returns causing garbled output).

### 2. Undefined variable in error message (line 82) — Fixes #406

**Before:**
```bash
log 'error' "No versions matching '${requested}' found in remote";
```
`${requested}` was never defined in this scope, causing an unbound variable crash under `set -u` before the error message could be displayed.

**After:**
```bash
log 'error' "No versions matching '${TFENV_VERSION}' found in remote";
```

## Testing

- Ran `./test/run.sh test_install_and_use.sh` on Linux (Ubuntu) — 41/41 tests pass, 0 failures.
- Cross-platform CI will validate macOS via the PR workflow.