### PR TITLE
Fix stray closing paren in syslog tag default in bashlog.sh

### DIFF
--- a/lib/bashlog.sh
+++ b/lib/bashlog.sh
@@ -27,7 +27,7 @@ function log() {
   local file_path="${BASHLOG_FILE_PATH:-/tmp/${0##*/}.log}";
   local json_path="${BASHLOG_JSON_PATH:-/tmp/${0##*/}.log.json}";
 
-  local tag="${BASHLOG_SYSLOG_TAG:-${0##*/})}";
+  local tag="${BASHLOG_SYSLOG_TAG:-${0##*/}}";
   local facility="${BASHLOG_SYSLOG_FACILITY:-local0}";
   local pid="${$}";
 


### PR DESCRIPTION
## Summary

Fixes #451

### Bug

In `lib/bashlog.sh` line 30, the syslog tag default had a literal `)` outside the parameter expansion:

```bash
# Before:
local tag="${BASHLOG_SYSLOG_TAG:-${0##*/})}";
# After:
local tag="${BASHLOG_SYSLOG_TAG:-${0##*/}}";
```

This caused every syslog message to have a malformed tag like `tfenv-install)` instead of `tfenv-install`.

### Testing

- `./test/run.sh test_list.sh` passes (exercises logging subsystem throughout).
- One-character fix with zero risk of side effects.