### PR TITLE
Fix unquoted argument iteration in tfenv-exec.sh

### DIFF
--- a/lib/tfenv-exec.sh
+++ b/lib/tfenv-exec.sh
@@ -29,7 +29,7 @@ function realpath-relative-to() {
 export -f realpath-relative-to;
 
 function tfenv-exec() {
-  for _arg in ${@:1}; do
+  for _arg in "${@}"; do
     if [[ "${_arg}" == -chdir=* ]]; then
       chdir="${_arg#-chdir=}";
       log 'debug' "Found -chdir arg: ${chdir}";


### PR DESCRIPTION
Fixes #453

`for _arg in ${@:1}` word-splits arguments containing spaces, breaking terraform commands that pass quoted args (e.g. `terraform import` with resource addresses containing brackets).

Changed to `for _arg in "${@}"` which preserves argument boundaries.

### Testing

- `./test/run.sh test_install_and_use.sh` — all tests pass on Linux.