### PR TITLE
Fix unquoted curl options in curlw() to handle paths with spaces

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -65,20 +65,19 @@ fi;
 
 # Curl wrapper to switch TLS option for each OS
 function curlw () {
-  local TLS_OPT="--tlsv1.2";
+  local -a tls_opt=(--tlsv1.2);
 
   # Check if curl is 10.12.6 or above
   if [[ -n "$(command -v sw_vers 2>/dev/null)" && ("$(sw_vers)" =~ 10\.12\.([6-9]|[0-9]{2}) || "$(sw_vers)" =~ 10\.1[3-9]) ]]; then
-    TLS_OPT="";
+    tls_opt=();
   fi;
 
+  local -a netrc_opt=();
   if [[ ! -z "${TFENV_NETRC_PATH:-""}" ]]; then
-    NETRC_OPT="--netrc-file ${TFENV_NETRC_PATH}";
-  else
-    NETRC_OPT="";
+    netrc_opt=(--netrc-file "${TFENV_NETRC_PATH}");
   fi;
 
-  curl ${TLS_OPT} ${NETRC_OPT} "$@";
+  curl ${tls_opt[@]+"${tls_opt[@]}"} ${netrc_opt[@]+"${netrc_opt[@]}"} "$@";
 };
 export -f curlw;
 


### PR DESCRIPTION
Fixes #454

Converts `TLS_OPT` and `NETRC_OPT` from strings to bash arrays so they are properly quoted when passed to curl. Previously, a `TFENV_NETRC_PATH` containing spaces would be word-split, breaking the curl call.

Uses the `${arr[@]+"${arr[@]}"}` expansion pattern for safe empty-array handling on bash <4.4 (macOS default bash 3.2 chokes on `"${empty_arr[@]}"` with `set -u`).

### Testing

- `./test/run.sh test_install_and_use.sh` — all tests pass on Linux (exercises curlw for every download).