### PR TITLE
Fix double-quoted trap in tfenv-install to handle paths safely

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -170,7 +170,8 @@ fi;
 download_tmp="$(mktemp -d ${tmpdir_arg} tfenv_download.XXXXXX)" || log 'error' "Unable to create temporary download directory (mktemp -d ${tmpdir_arg} tfenv_download.XXXXXX). Working Directory is: $(pwd)";
 
 # Clean it up in case of error
-trap "rm -rf ${download_tmp}" EXIT;
+cleanup_download() { rm -rf "${download_tmp}"; }
+trap cleanup_download EXIT;
 
 declare curl_progress="";
 case "${TFENV_CURL_OUTPUT:-2}" in


### PR DESCRIPTION
Fixes #455

Replaces the double-quoted trap string with a cleanup function:

```bash
# Before:
trap "rm -rf ${download_tmp}" EXIT;

# After:
cleanup_download() { rm -rf "${download_tmp}"; }
trap cleanup_download EXIT;
```

The previous pattern expanded `${download_tmp}` at trap definition time without quotes, making it vulnerable to word-splitting if the temp path contained spaces or shell metacharacters. The function approach expands the variable at execution time with proper quoting.

### Testing

- `./test/run.sh test_install_and_use.sh` — all tests pass on Linux (exercises the install codepath and temp cleanup for every version installed).