### PR TITLE
Fix test infrastructure bugs: undefined function and missing quotes

### DIFF
--- a/test/test_common.sh
+++ b/test/test_common.sh
@@ -30,7 +30,7 @@ if [ -z "${TFENV_ROOT:-""}" ]; then
   };
 
   TFENV_ROOT="$(cd "$(dirname "$(readlink_f "${0}")")/.." && pwd)";
-  [ -n ${TFENV_ROOT} ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
+  [ -n "${TFENV_ROOT}" ] || early_death "Failed to 'cd \"\$(dirname \"\$(readlink_f \"${0}\")\")/..\" && pwd' while trying to determine TFENV_ROOT";
 else
   TFENV_ROOT="${TFENV_ROOT%/}";
 fi;

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -49,7 +49,7 @@ for ((test_num=0; test_num<${tests_count}; ++test_num )) ; do
 done;
 
 echo "### Uninstall removes versions directory"
-cleanup || error_and_die "Cleanup failed?!"
+cleanup || error_and_proceed "Cleanup failed?!"
 (
   tfenv install 0.12.1 || exit 1
   tfenv install 0.12.2 || exit 1


### PR DESCRIPTION
Fixes #456, #457

Two test infrastructure bugs:

### 1. `error_and_die` does not exist in test context (#456)

`test/test_uninstall.sh` line 52 calls `error_and_die` which is not defined in the test framework. Changed to `error_and_proceed` which is the correct test helper (logs the failure and increments the error counter for summary reporting).

### 2. Missing quotes around `${TFENV_ROOT}` (#457)

`test/test_common.sh` line 33: `[ -n ${TFENV_ROOT} ]` always evaluates true even when `TFENV_ROOT` is empty, because without quotes the shell sees `[ -n ]` which tests whether `-n` is non-empty (it is). Added quotes: `[ -n "${TFENV_ROOT}" ]`.

### Testing

- `./test/run.sh test_uninstall.sh` — all tests pass on Linux, including the previously broken cleanup path.