### PR TITLE
Fix #452, Fix #460: Remove dead code, fix indentation, add SHA256 success log

### DIFF
--- a/bin/tfenv
+++ b/bin/tfenv
@@ -84,7 +84,6 @@ case "${arg}" in
       tfenv---version;
       tfenv-help;
     } | abort && exit 1;
-exit 1;
     ;;
   -v | --version )
     log 'debug' 'tfenv version requested...';

--- a/lib/tfenv-exec.sh
+++ b/lib/tfenv-exec.sh
@@ -50,12 +50,12 @@ function tfenv-exec() {
   export TFENV_VERSION;
 
   if [ ! -d "${TFENV_CONFIG_DIR}/versions/${TFENV_VERSION}" ]; then
-  if [ "${TFENV_AUTO_INSTALL:-true}" == "true" ]; then
-    if [ -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
-      TFENV_VERSION_SOURCE="$(tfenv-version-file)";
-    else
-      TFENV_VERSION_SOURCE='TFENV_TERRAFORM_VERSION';
-    fi;
+    if [ "${TFENV_AUTO_INSTALL:-true}" == "true" ]; then
+      if [ -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
+        TFENV_VERSION_SOURCE="$(tfenv-version-file)";
+      else
+        TFENV_VERSION_SOURCE='TFENV_TERRAFORM_VERSION';
+      fi;
       log 'info' "version '${TFENV_VERSION}' is not installed (set by ${TFENV_VERSION_SOURCE}). Installing now as TFENV_AUTO_INSTALL==true";
       tfenv-install;
     else

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -280,13 +280,15 @@ if [[ -n "${shasum_bin}" && -x "${shasum_bin}" ]]; then
       -a 256 \
       -s \
       -c <(grep -F "${tarball_name}" "${shasums_name}")
-  ) || log 'error' 'SHA256 hash does not match!';
+  ) && log 'info' 'SHA256 hash matched!' \
+    || log 'error' 'SHA256 hash does not match!';
 elif [[ -n "${sha256sum_bin}" && -x "${sha256sum_bin}" ]]; then
   (
     cd "${download_tmp}";
     "${sha256sum_bin}" \
       -c <(grep -F "${tarball_name}" "${shasums_name}")
-  ) || log 'error' 'SHA256 hash does not match!';
+  ) && log 'info' 'SHA256 hash matched!' \
+    || log 'error' 'SHA256 hash does not match!';
 else
   # Lack of shasum deserves a proper warning
   log 'warn' 'No shasum tool available. Skipping SHA256 hash validation';


### PR DESCRIPTION
Three trivial cleanup items:

1. Fix #452: Remove unreachable exit 1 dead code in bin/tfenv. The preceding abort && exit 1 already handles the exit.

2. Fix #460: Fix mixed indentation in the auto-install block of lib/tfenv-exec.sh. The if/else/fi blocks were at inconsistent indent levels.

3. SHA256 success message: Add info log on successful hash verification in libexec/tfenv-install. Previously the hash check only logged on failure or skip, leaving users unsure whether verification ran (see #369).