### PR TITLE
Fix #441: CLI argument takes precedence over TFENV_TERRAFORM_VERSION

### DIFF
--- a/libexec/tfenv-resolve-version
+++ b/libexec/tfenv-resolve-version
@@ -71,7 +71,13 @@ declare version_requested version regex min_required version_file;
 
 declare arg="${1:-""}";
 
-if [ -z "${arg}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
+if [ -n "${arg}" ]; then
+  version_requested="${arg}";
+  log 'debug' "Version requested on command line: ${version_requested}";
+elif [ -n "${TFENV_TERRAFORM_VERSION:-""}" ]; then
+  version_requested="${TFENV_TERRAFORM_VERSION}";
+  log 'debug' "TFENV_TERRAFORM_VERSION is set: ${TFENV_TERRAFORM_VERSION}";
+else
   version_file="$(tfenv-version-file)";
   log 'debug' "Version File: ${version_file}";
 
@@ -91,16 +97,11 @@ if [ -z "${arg}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
       version_requested='latest';
     fi;
 
-  else 
+  else
     log 'debug' "Version File is the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version) but it doesn't exist";
     log 'debug' 'No version requested on the command line or in the version file search path. Installing "latest"';
     version_requested='latest';
   fi;
-elif [ -n "${TFENV_TERRAFORM_VERSION:-""}" ]; then
-  version_requested="${TFENV_TERRAFORM_VERSION}";
-  log 'debug' "TFENV_TERRAFORM_VERSION is set: ${TFENV_TERRAFORM_VERSION}";
-else
-  version_requested="${arg}";
 fi;
 
 [[ -n "${version_requested:-""}" ]] \


### PR DESCRIPTION
Fix #441

When running `tfenv install 1.10.2` with `TFENV_TERRAFORM_VERSION=1.9.5` set, the env var previously took priority and 1.9.5 was installed instead of the explicitly requested 1.10.2.

The version resolution priority in `tfenv-resolve-version` is now:
1. Explicit CLI argument (highest priority)
2. TFENV_TERRAFORM_VERSION environment variable
3. Version file (.terraform-version or default)

This matches user expectation: if you explicitly ask for a version, that is what you get.