### PR TITLE
Fix #374: Route tfenv log output to stderr in terraform shim context

### DIFF
--- a/bin/terraform
+++ b/bin/terraform
@@ -58,6 +58,12 @@ done;
 # Begin Script Body #
 #####################
 
+# Signal to bashlog that we are in the terraform shim context.
+# All tfenv log output (info, warn) should go to stderr so it does
+# not mix with terraform's stdout and break piped commands like:
+#   terraform version -json | jq
+export TFENV_SHIM_MODE=1;
+
 log 'debug' "program=\"${0##*/}\"";
 
 declare tfenv_path="${TFENV_ROOT}/bin/tfenv";

--- a/lib/bashlog.sh
+++ b/lib/bashlog.sh
@@ -136,7 +136,13 @@ function log() {
   # Standard Output (Pretty)
   case "${level}" in
     'info'|'warn')
-      echo -e "${std_line}";
+      if [ "${TFENV_SHIM_MODE:-0}" -eq 1 ]; then
+        # In shim mode (bin/terraform), all tfenv output goes to stderr
+        # to avoid corrupting terraform's stdout (e.g. terraform version -json | jq)
+        echo -e "${std_line}" >&2;
+      else
+        echo -e "${std_line}";
+      fi;
       ;;
     'debug')
       if [ "${debug_level}" -gt 0 ]; then


### PR DESCRIPTION
Fix #374

When TFENV_AUTO_INSTALL triggers during a piped terraform command (e.g. `terraform version -json | jq`), tfenv info messages were sent to stdout and mixed with terraform output, corrupting the JSON.

This fix sets `TFENV_SHIM_MODE=1` in `bin/terraform` (the shim). When this variable is set, bashlog routes `info` and `warn` messages to stderr instead of stdout. This is targeted to the shim path only — direct `tfenv` commands like `tfenv install` still output info to stdout as before.

The change follows Unix convention: tools acting as transparent proxies should not pollute stdout with their own messages.