### PR TITLE
Fix #375, Fix #204: Filter pre-release versions from latest resolution

### DIFF
--- a/lib/tfenv-version-name.sh
+++ b/lib/tfenv-version-name.sh
@@ -55,11 +55,21 @@ function tfenv-version-name() {
 
     declare local_version='';
     if [[ -d "${TFENV_CONFIG_DIR}/versions" ]]; then
-      local_version="$(\find "${TFENV_CONFIG_DIR}/versions/" -type d -exec basename {} \; \
-        | tail -n +2 \
-        | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
-        | grep -e "${regex}" \
-        | head -n 1)";
+      # Exclude pre-releases only for version-number-only regexes (not latest:rc etc.)
+      if [[ -n "${regex}" && ! "${regex}" =~ [a-zA-Z] ]]; then
+        local_version="$(\find "${TFENV_CONFIG_DIR}/versions/" -type d -exec basename {} \; \
+          | tail -n +2 \
+          | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
+          | grep -e "${regex}" \
+          | grep -v '-' \
+          | head -n 1)";
+      else
+        local_version="$(\find "${TFENV_CONFIG_DIR}/versions/" -type d -exec basename {} \; \
+          | tail -n +2 \
+          | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3nr,3 \
+          | grep -e "${regex}" \
+          | head -n 1)";
+      fi;
 
       log 'debug' "Resolved ${TFENV_VERSION} to locally installed version: ${local_version}";
     elif [[ "${auto_install}" != "true" ]]; then
@@ -68,7 +78,12 @@ function tfenv-version-name() {
 
     if [[ "${auto_install}" == "true" ]]; then
       log 'debug' "Using latest keyword and auto_install means the current version is whatever is latest in the remote. Trying to find the remote version using the regex: ${regex}";
-      remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)";
+      # Exclude pre-releases only for version-number-only regexes
+      if [[ -n "${regex}" && ! "${regex}" =~ [a-zA-Z] ]]; then
+        remote_version="$(tfenv-list-remote | grep -e "${regex}" | grep -v '-' | head -n 1)";
+      else
+        remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)";
+      fi;
       if [[ -n "${remote_version}" ]]; then
           if [[ "${local_version}" != "${remote_version}" ]]; then
             log 'debug' "The installed version '${local_version}' does not much the remote version '${remote_version}'";

--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -73,8 +73,16 @@ declare regex="${resolved##*\:}";
 
 log 'debug' "Processing install for version ${version}, using regex ${regex}";
 
+# When resolving 'latest' with a version-number-only regex (e.g. latest:^0.11.
+# from latest-allowed), exclude pre-release versions (alpha, beta, rc) which
+# contain a hyphen. Regexes containing letters (e.g. latest:rc, latest:alpha)
+# are intentionally targeting pre-releases and are not filtered.
 if [ "${TFENV_SKIP_REMOTE_CHECK:-0}" -eq 0 ]; then
-  remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)";
+  if [[ "${version}" == "latest" && -n "${regex}" && ! "${regex}" =~ [a-zA-Z] ]]; then
+    remote_version="$(tfenv-list-remote | grep -e "${regex}" | grep -v '-' | head -n 1)";
+  else
+    remote_version="$(tfenv-list-remote | grep -e "${regex}" | head -n 1)";
+  fi;
   [ -n "${remote_version}" ] && version="${remote_version}" || log 'error' "No versions matching '${requested:-$version}' found in remote";
 fi;
 

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -100,12 +100,23 @@ declare installed_version='';
 log 'debug' "Searching ${TFENV_CONFIG_DIR}/versions/ for latest version matching ${regex}";
 
 if [ -d "${TFENV_CONFIG_DIR}/versions" ]; then
-  installed_version="$(\find "${TFENV_CONFIG_DIR}/versions/" -type d -exec basename {} \; \
-    | tail -n +2 \
-    | grep -e "${regex}" \
-    | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3r,3 \
-    | head -n 1
-  )";
+  # Exclude pre-releases only for version-number-only regexes (not latest:rc etc.)
+  if [[ "${version}" == "latest" && -n "${regex}" && ! "${regex}" =~ [a-zA-Z] ]]; then
+    installed_version="$(\find "${TFENV_CONFIG_DIR}/versions/" -type d -exec basename {} \; \
+      | tail -n +2 \
+      | grep -e "${regex}" \
+      | grep -v '-' \
+      | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3r,3 \
+      | head -n 1
+    )";
+  else
+    installed_version="$(\find "${TFENV_CONFIG_DIR}/versions/" -type d -exec basename {} \; \
+      | tail -n +2 \
+      | grep -e "${regex}" \
+      | sort -t'.' -k 1nr,1 -k 2nr,2 -k 3r,3 \
+      | head -n 1
+    )";
+  fi;
 fi;
 
 if [ -n "${installed_version}" ]; then


### PR DESCRIPTION
Fix #375, Fix #204

All `latest*` resolution paths now exclude pre-release versions (containing a hyphen: alpha, beta, rc) when selecting the top match.

**The problem:** `latest:^1\.` could return `1.10.0-alpha1` instead of the latest stable 1.x. Similarly, `latest-allowed` with `~> 1.2` could install a beta. `latest:^0.13` would prefer `0.13.0-beta2` over `0.13.0-rc1` or stable releases.

**The fix:** Added `grep -v '-'` to filter pre-releases in:
- `libexec/tfenv-install` (remote version lookup)
- `libexec/tfenv-use` (local version lookup)
- `lib/tfenv-version-name.sh` (local and remote version lookup)

The `latest` keyword alone already excluded pre-releases via its `^[0-9]+\.[0-9]+\.[0-9]+$` regex (the `$` anchor prevents matching). This fix extends the same protection to `latest:<regex>` and `latest-allowed`.

Users who want a specific pre-release should pin it explicitly (e.g. `1.0.0-rc1` in `.terraform-version`).

Credit to @vahid-haghighat whose analysis in PR #439 informed this fix.