### PR TITLE
Feat #229: Load bashlog conditionally based on shell interactivity

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -47,19 +47,47 @@ function load_bashlog () {
 };
 export -f load_bashlog;
 
-if [ "${TFENV_DEBUG:-0}" -gt 0 ] ; then
-  # our shim below cannot be used when debugging is enabled
+# Lightweight log function used when bashlog is not loaded.
+# Handles 'error' (exit 1) and 'debug' (no-op), everything else goes to stderr.
+function _tfenv_lightweight_log () {
+  if [ "${1}" == 'debug' ]; then
+    return;
+  fi;
+  if [ "${1}" == 'error' ]; then
+    echo -e "tfenv: [ERROR] ${*:2}" >&2;
+    exit 1;
+  fi;
+  echo -e "tfenv: ${*:2}" >&2;
+};
+export -f _tfenv_lightweight_log;
+
+# Determine whether to load full bashlog:
+#   TFENV_BASHLOG=1        → always load
+#   TFENV_BASHLOG=0        → never load (lightweight log)
+#   TFENV_BASHLOG unset    → auto: interactive shell loads bashlog, non-interactive does not
+#   TFENV_DEBUG > 0        → always load (overrides TFENV_BASHLOG=0)
+if [ "${TFENV_DEBUG:-0}" -gt 0 ]; then
+  # Debug mode always needs full bashlog
   load_bashlog;
-else
-  # Shim that understands to no-op for debug messages, and defers to
-  # full bashlog for everything else.
+elif [ "${TFENV_BASHLOG:-auto}" == '1' ]; then
+  # Explicitly requested full bashlog
+  load_bashlog;
+elif [ "${TFENV_BASHLOG:-auto}" == '0' ]; then
+  # Explicitly disabled bashlog
+  function log () { _tfenv_lightweight_log "$@"; };
+  export -f log;
+elif [[ $- == *i* ]]; then
+  # Interactive shell: use deferred loading shim (current default behaviour)
   function log () {
-    if [ "$1" != 'debug' ] ; then
-      # Loading full bashlog will overwrite the `log` function
+    if [ "$1" != 'debug' ]; then
       load_bashlog;
       log "$@";
     fi;
   };
+  export -f log;
+else
+  # Non-interactive shell: use lightweight log by default
+  function log () { _tfenv_lightweight_log "$@"; };
   export -f log;
 fi;
 


### PR DESCRIPTION
Close #229

Bashlog is a full-featured logging library (syslog, file, JSON, colour output) that adds measurable overhead on every tfenv invocation. In non-interactive contexts (CI pipelines, scripts, terraform shim), the advanced logging features are rarely needed, and the overhead is wasteful.

## Changes

Non-interactive shells now use a lightweight log function by default that simply echoes to stderr with a `tfenv:` prefix. Interactive shells retain the current deferred-loading behaviour.

### New: `TFENV_BASHLOG` environment variable

| Value | Behaviour |
|-------|-----------|
| `1` | Always load full bashlog |
| `0` | Always use lightweight log |
| *(unset)* | Auto-detect: interactive → bashlog, non-interactive → lightweight |

`TFENV_DEBUG > 0` always loads full bashlog regardless of `TFENV_BASHLOG`.

### Lightweight log function

The lightweight replacement handles:
- `debug` → no-op (same as current shim)
- `error` → print to stderr and `exit 1`
- everything else → print to stderr with `tfenv:` prefix

This preserves the existing contract that all scripts rely on (`log LEVEL MESSAGE`).

## Backwards Compatibility

- **Interactive shells**: No change — behaves exactly as before
- **Non-interactive shells**: Now uses lightweight log by default. Users who need full bashlog in non-interactive contexts can set `TFENV_BASHLOG=1`
- **TFENV_DEBUG**: Still works exactly as before