### PR TITLE
Fix test runner and test scripts to exit with correct status codes

### DIFF
--- a/test/run.sh
+++ b/test/run.sh
@@ -25,8 +25,11 @@ if [ "${#errors[@]}" -ne 0 ]; then
     log 'warn' "\t${error}";
   done;
   log 'error' 'Test suite failure(s)';
+  # log 'error' exits 1, but be explicit in case log behaviour changes
+  exit 1;
 else
   log 'info' 'All test suites passed.';
 fi;
 
 exit 0;
+# vi: set ts=2 sw=2 et:

--- a/test/test_install_and_use.sh
+++ b/test/test_install_and_use.sh
@@ -224,6 +224,7 @@ if [ "${#errors[@]}" -gt 0 ]; then
     log 'warn' "\t${error}";
   done
   log 'error' 'Test failure(s): install_and_use';
+  exit 1;
 else
   log 'info' 'All install_and_use tests passed';
 fi;

--- a/test/test_list.sh
+++ b/test/test_list.sh
@@ -48,6 +48,7 @@ if [ "${#errors[@]}" -gt 0 ]; then
     log 'warn' "\t${error}";
   done;
   log 'error' 'List test failure(s)';
+  exit 1;
 else
   log 'info' 'All list tests passed.';
 fi;

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -66,6 +66,7 @@ if [ "${#errors[@]}" -gt 0 ]; then
     log 'warn' "\t${error}";
   done;
   log 'error' 'List test failure(s)';
+  exit 1;
 else
   log 'info' 'All list tests passed.';
 fi;

--- a/test/test_use_latestallowed.sh
+++ b/test/test_use_latestallowed.sh
@@ -93,6 +93,7 @@ if [ "${#errors[@]}" -gt 0 ]; then
     log 'warn' "\t${error}";
   done;
   log 'error' 'use_latestallowed test failure(s)';
+  exit 1;
 else
   log 'info' 'All use_latestallowed tests passed.';
 fi;

--- a/test/test_use_minrequired.sh
+++ b/test/test_use_minrequired.sh
@@ -121,6 +121,7 @@ if [ "${#errors[@]}" -gt 0 ]; then
     log 'warn' "\t${error}";
   done;
   log 'error' 'use_minrequired test failure(s)';
+  exit 1;
 else
   log 'info' 'All use_minrequired tests passed.';
 fi;


### PR DESCRIPTION
All test scripts and the test runner (`test/run.sh`) used `exit 0` unconditionally at the end. While `log 'error'` calls `exit 1` internally (in bashlog), relying on that side effect is fragile — if log behaviour ever changes, test failures would be silently masked.

Added explicit `exit 1` after every `log 'error'` in the error-handling block of:
- `test/run.sh`
- `test/test_install_and_use.sh`
- `test/test_list.sh`
- `test/test_uninstall.sh`
- `test/test_use_latestallowed.sh`
- `test/test_use_minrequired.sh`

`test/test_symlink.sh` already had this — no change needed.

The `exit 0` at the end of each file now genuinely only executes on success, making CI exit codes reliable.