### PR TITLE
Fix #442: Do not assume brew is available for GNU grep detection

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -146,13 +146,21 @@ function error_and_proceed() {
 export -f error_and_proceed;
 
 function check_dependencies() {
-  if [[ $(uname) == 'Darwin' ]] && [ $(which brew) ]; then
-    if ! [ $(which ggrep) ]; then
-      log 'error' 'A metaphysical dichotomy has caused this unit to overload and shut down. GNU Grep is a requirement and your Mac does not have it. Consider "brew install grep"';
+  if [[ "$(uname)" == 'Darwin' ]]; then
+    # Prefer ggrep (typically from Homebrew) if available
+    if command -v ggrep >/dev/null 2>&1; then
+      shopt -s expand_aliases;
+      alias grep=ggrep;
+      return;
     fi;
 
-    shopt -s expand_aliases;
-    alias grep=ggrep;
+    # Fall back to checking if the system grep is GNU grep
+    # (e.g. installed via nix or manually)
+    if grep --version 2>&1 | grep -q 'GNU grep'; then
+      return;
+    fi;
+
+    log 'error' 'GNU Grep is a requirement and your Mac does not have it. Consider "brew install grep" or "nix profile install nixpkgs#gnugrep"';
   fi;
 };
 export -f check_dependencies;


### PR DESCRIPTION
Fix #442

On macOS, tfenv requires GNU grep for extended regex support. Previously, `check_dependencies` assumed Homebrew was the only way to install GNU grep — if `brew` was not found, detection was skipped entirely.

This broke tfenv on macOS systems using **nix**, **MacPorts**, or **manual** GNU grep installations.

## New detection order

1. Check for `ggrep` (Homebrew installs GNU grep as ggrep) → alias to `grep`
2. Check if the system `grep` is GNU grep (nix, manual install) → use as-is
3. Error with installation suggestions for both brew and nix

## Also fixes

- Replaces `$(which ...)` with `command -v` (POSIX portable, no external dependency)
- Quotes the `uname` check

## Credit

Inspired by PR #442 (credit to @davidmh). Written from scratch with a simpler implementation.