### PR TITLE
Fix #368, Fix #379: Support exact version constraints + docs update

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Currently tfenv supports the following OSes
 - Linux
   - 64bit
   - Arm
-- Windows (64bit) - only tested in git-bash - currently presumed failing due to symlink issues in git-bash
+- Windows (64bit) - tested in git-bash. Ensure `core.symlinks` is enabled (`git config --global core.symlinks true`)
 
 ## Installation
 
@@ -154,6 +154,18 @@ terraform {
   required_version  = "~> 0.10.0, <0.12.3"
 }
 ```
+
+##### Supported `latest-allowed` constraint operators
+
+`latest-allowed` reads the first `required_version` value from your `.tf` files and resolves
+the latest installable version. Only the first constraint before any comma is evaluated.
+
+| Constraint | Behaviour | Example | Resolves to |
+|------------|-----------|---------|-------------|
+| `>` or `>=` | Installs the latest available version | `">= 1.0.0"` | latest |
+| `<=` | Installs that exact version | `"<= 1.2.3"` | `1.2.3` |
+| `~>` | Installs the latest version matching the prefix | `"~> 1.2.0"` | latest `1.2.x` |
+| `=` or bare version | Installs that exact version | `"0.12.31"` or `"= 0.12.31"` | `0.12.31` |
 
 ### Environment Variables
 

--- a/libexec/tfenv-resolve-version
+++ b/libexec/tfenv-resolve-version
@@ -145,7 +145,12 @@ if [[ "${version_requested}" =~ ^latest-allowed$ ]]; then
       version_requested="latest:^${version_without_rightmost}\.";
       ;;
     *)
-      log 'error' "Unsupported version spec: '${version_spec}', only >, >=, <=, and ~> are supported.";
+      # Treat bare version numbers (e.g. "0.12.31") and = prefix as exact pins
+      if [[ "${version_num}" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+        version_requested="${version_num}";
+      else
+        log 'error' "Unsupported version spec: '${version_spec}', only exact versions, >, >=, <=, and ~> are supported.";
+      fi;
       ;;
   esac;
   log 'debug' "Determined the requested version to be: ${version_requested}";


### PR DESCRIPTION
Fix #368, Fix #379

## Fix #368: Support exact version constraints in latest-allowed

`latest-allowed` now handles bare version numbers (e.g. `"0.12.31"`) and `=` prefixed versions (e.g. `"= 0.12.31"`) in `required_version`. Previously these hit the catch-all error: `Unsupported version spec`.

Also adds a constraint operator reference table to the README documenting all supported operators:

| Constraint | Behaviour | Example | Resolves to |
|------------|-----------|---------|-------------|
| `>` or `>=` | Latest available | `">= 1.0.0"` | latest |
| `<=` | Exact version | `"<= 1.2.3"` | `1.2.3` |
| `~>` | Latest matching prefix | `"~> 1.2.0"` | latest `1.2.x` |
| `=` or bare version | Exact version | `"0.12.31"` | `0.12.31` |

## Fix #379: Update Windows status

Removes the "presumed failing due to symlink issues" language from the README since CI tests pass on Windows (windows-2025 and windows-2022) and community reports confirm it works with git-bash when `core.symlinks` is enabled.