### PR TITLE
chore(Dockerfile): bump TFENV_VERSION to 3.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache --purge \
     curl \
     ;
 
-ARG TFENV_VERSION=3.0.0
+ARG TFENV_VERSION=3.1.0
 RUN wget -O /tmp/tfenv.tar.gz "https://github.com/tfutils/tfenv/archive/refs/tags/v${TFENV_VERSION}.tar.gz" \
     && tar -C /tmp -xf /tmp/tfenv.tar.gz \
     && mv "/tmp/tfenv-${TFENV_VERSION}/bin"/* /usr/local/bin/ \


### PR DESCRIPTION
Now that v3.1.0 has been tagged and released, update the Dockerfile to pull from the new release tarball.

This was intentionally deferred from the release PR (#478) to avoid a chicken-and-egg problem — the Docker build downloads the release tarball, which does not exist until the tag is pushed.