### PR TITLE
feat: support comments in .terraform-version files

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -109,6 +109,14 @@ function curlw () {
 };
 export -f curlw;
 
+# Read a version file, stripping comments (lines starting with #) and blank lines,
+# and removing carriage returns for Windows/WSL compatibility.
+function read_version_file() {
+  local file="${1}";
+  sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${file}" | tr -d '\r';
+};
+export -f read_version_file;
+
 function check_active_version() {
   local v="${1}";
   local maybe_chdir=;
@@ -137,7 +145,7 @@ export -f check_installed_version;
 
 function check_default_version() {
   local v="${1}";
-  local def="$(cat "${TFENV_CONFIG_DIR}/version")";
+  local def="$(read_version_file "${TFENV_CONFIG_DIR}/version")";
   [ "${def}" == "${v}" ];
 };
 export -f check_default_version;

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -113,7 +113,7 @@ export -f curlw;
 # and removing carriage returns for Windows/WSL compatibility.
 function read_version_file() {
   local file="${1}";
-  sed -e 's/#.*$//' -e '/^[[:space:]]*$/d' "${file}" | tr -d '\r';
+  sed -e 's/#.*$//' -e 's/[[:space:]]*$//' -e '/^[[:space:]]*$/d' "${file}" | tr -d '\r';
 };
 export -f read_version_file;
 

--- a/lib/tfenv-version-name.sh
+++ b/lib/tfenv-version-name.sh
@@ -10,7 +10,7 @@ function tfenv-version-name() {
       && log 'debug' "TFENV_VERSION_FILE retrieved from tfenv-version-file: ${TFENV_VERSION_FILE}" \
       || log 'error' 'Failed to retrieve TFENV_VERSION_FILE from tfenv-version-file';
 
-    TFENV_VERSION="$(cat "${TFENV_VERSION_FILE}" | tr -d '\r' || true)" \
+    TFENV_VERSION="$(read_version_file "${TFENV_VERSION_FILE}" || true)" \
       && log 'debug' "TFENV_VERSION specified in TFENV_VERSION_FILE: ${TFENV_VERSION}";
 
     TFENV_VERSION_SOURCE="${TFENV_VERSION_FILE}";

--- a/libexec/tfenv-resolve-version
+++ b/libexec/tfenv-resolve-version
@@ -83,12 +83,12 @@ else
 
   if [ "${version_file}" != "${TFENV_CONFIG_DIR}/version" ]; then
     log 'debug' "Version File (${version_file}) is not the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version)";
-    version_requested="$(cat "${version_file}" | tr -d '\r')" \
+    version_requested="$(read_version_file "${version_file}")" \
       || log 'error' "Failed to open ${version_file}";
 
   elif [ -f "${version_file}" ]; then
     log 'debug' "Version File is the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version)";
-    version_requested="$(cat "${version_file}" | tr -d '\r')" \
+    version_requested="$(read_version_file "${version_file}")" \
       || log 'error' "Failed to open ${version_file}";
 
     # Absolute fallback

--- a/libexec/tfenv-uninstall
+++ b/libexec/tfenv-uninstall
@@ -69,11 +69,11 @@ if [ -z "${arg:-""}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
   log 'debug' "Version File: ${version_file}";
   if [ "${version_file}" != "${TFENV_CONFIG_DIR}/version" ]; then
     log 'debug' "Version File (${version_file}) is not the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version)";
-    version_requested="$(cat "${version_file}")" \
+    version_requested="$(read_version_file "${version_file}")" \
       || log 'error' "Failed to open ${version_file}";
   elif [ -f "${version_file}" ]; then
     log 'debug' "Version File is the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version)";
-    version_requested="$(cat "${version_file}")" \
+    version_requested="$(read_version_file "${version_file}")" \
       || log 'error' "Failed to open ${version_file}";
   else
     log 'debug' "Version File is the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version) but it doesn't exist";

--- a/libexec/tfenv-use
+++ b/libexec/tfenv-use
@@ -76,7 +76,7 @@ if [ -z "${requested_arg}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
   version_source_suffix=" (set by ${loaded_version_file})";
 
   if [ -f "${loaded_version_file}" ]; then
-    requested="$(cat "${loaded_version_file}" || true)";
+    requested="$(read_version_file "${loaded_version_file}" || true)";
   else
     # No-one asked for anything, no default version is set either
     requested='latest';

--- a/test/test_version_file.sh
+++ b/test/test_version_file.sh
@@ -105,6 +105,29 @@ cleanup || log 'error' 'Cleanup failed?!';
 ) && log 'info' '## version-file: working directory resolution passed' \
   || error_and_proceed 'version-file did not find .terraform-version from working directory';
 
+
+log 'info' '## version-file: comments and blank lines are stripped';
+cleanup || log 'error' 'Cleanup failed?!';
+(
+  # Write a version file with comments and blank lines
+  printf '# This is a comment\n\n# Use 1.0 series\nlatest:^1\\.0\\.\n\n' > .terraform-version;
+  declare vn;
+  vn="$(tfenv version-name)";
+  # Should resolve to the version spec, not the comment
+  [[ "${vn}" =~ ^1\.0\. ]] || { echo "Expected 1.0.x but got: ${vn}"; exit 1; };
+) && log 'info' '## version-file: comments stripped passed' \
+  || error_and_proceed 'version-file did not strip comments correctly';
+
+log 'info' '## version-file: inline comments are stripped';
+cleanup || log 'error' 'Cleanup failed?!';
+(
+  echo '1.0.0 # pinned for compatibility' > .terraform-version;
+  declare vn;
+  vn="$(tfenv version-name)";
+  [ "${vn}" == '1.0.0' ] || { echo "Expected 1.0.0 but got: ${vn}"; exit 1; };
+) && log 'info' '## version-file: inline comments passed' \
+  || error_and_proceed 'version-file did not strip inline comments correctly';
+
 finish_tests 'version_file';
 
 exit 0;


### PR DESCRIPTION
Lines starting with `#` and inline `# comments` are now stripped when reading version files. Blank lines are also ignored.

This allows users to annotate their `.terraform-version` files:

```
# Pin to 1.x for module compatibility
latest:^1\.

# Or use an exact version
# 1.5.7
```

**Implementation:** Introduces `read_version_file()` helper in `lib/helpers.sh`, used by all 6 places that read version files (`tfenv-version-name.sh`, `tfenv-resolve-version`, `tfenv-use`, `tfenv-uninstall`, `helpers.sh:check_default_version`). The helper uses `sed` to strip `#` comments and blank lines, and `tr` to remove carriage returns.

**Tests:** Two new test cases in `test_version_file.sh` — full-line comments with blank lines, and inline comments.

Fixes #391, fixes #283