### PR TITLE
feat: support uninstalling multiple versions (#449)

### DIFF
--- a/libexec/tfenv-help
+++ b/libexec/tfenv-help
@@ -7,7 +7,7 @@ echo 'Usage: tfenv <command> [<options>]
 Commands:
    install       Install a specific version of Terraform
    use           Switch a version to use
-   uninstall     Uninstall a specific version of Terraform
+   uninstall     Uninstall one or more versions of Terraform
    list          List all installed versions
    list-remote   List all installable versions
    version-name  Print current version

--- a/libexec/tfenv-uninstall
+++ b/libexec/tfenv-uninstall
@@ -59,69 +59,85 @@ done;
 # Begin Script Body #
 #####################
 
-[ "${#}" -gt 1 ] && log 'error' 'usage: tfenv uninstall [<version>]';
+uninstall_single_version() {
+  local version_requested="${1}";
 
-declare version_requested version regex;
-declare arg="${1:-""}";
+  log 'debug' "Version Requested: ${version_requested}";
 
-if [ -z "${arg:-""}" -a -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
+  if [[ "${version_requested}" =~ ^min-required$ ]]; then
+    log 'error' 'min-required is an unsupported option for uninstall';
+  fi;
+
+  if [[ "${version_requested}" == latest-allowed ]]; then
+    log 'error' 'latest-allowed is an unsupported option for uninstall';
+  fi;
+
+  local version regex;
+  if [[ "${version_requested}" =~ ^latest\:.*$ ]]; then
+    version="${version_requested%%\:*}";
+    regex="${version_requested##*\:}";
+  elif [[ "${version_requested}" =~ ^latest$ ]]; then
+    version="${version_requested}";
+    regex="";
+  else
+    version="${version_requested}";
+    regex="^${version_requested}$";
+  fi;
+
+  [ -z "${version:-""}" ] && log 'error' "Version not specified.";
+
+  log 'debug' "Processing uninstall for version ${version}, using regex ${regex}";
+
+  version="$(tfenv-list | sed -E 's/^(\*| )? //g; s/ \(set by .+\)$//' | grep -e "${regex}" | head -n 1)";
+  [ -n "${version}" ] || log 'error' "No versions matching '${regex}' found in local";
+
+  local dst_path="${TFENV_CONFIG_DIR}/versions/${version}";
+  if [ -f "${dst_path}/terraform" ]; then
+    log 'info' "Uninstall Terraform v${version}";
+    rm -r "${dst_path}";
+    log 'info' "Terraform v${version} is successfully uninstalled";
+  else
+    log 'error' "Terraform v${version} is not installed";
+  fi;
+};
+
+# Collect versions to uninstall
+declare -a versions_to_uninstall=();
+
+if [ "${#}" -eq 0 ] && [ -z "${TFENV_TERRAFORM_VERSION:-""}" ]; then
+  # No args: read from version file
   version_file="$(tfenv-version-file)";
   log 'debug' "Version File: ${version_file}";
   if [ "${version_file}" != "${TFENV_CONFIG_DIR}/version" ]; then
     log 'debug' "Version File (${version_file}) is not the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version)";
-    version_requested="$(cat "${version_file}")" \
+    versions_to_uninstall+=("$(cat "${version_file}")") \
       || log 'error' "Failed to open ${version_file}";
   elif [ -f "${version_file}" ]; then
     log 'debug' "Version File is the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version)";
-    version_requested="$(cat "${version_file}")" \
+    versions_to_uninstall+=("$(cat "${version_file}")") \
       || log 'error' "Failed to open ${version_file}";
   else
-    log 'debug' "Version File is the default \${TFENV_CONFIG_DIR}/version (${TFENV_CONFIG_DIR}/version) but it doesn't exist";
-    log 'info' 'No version requested on the command line or in the version file search path. Installing "latest"';
-    version_requested='latest';
+    log 'error' 'No version requested on the command line or in the version file search path.';
   fi;
-elif [ -n "${TFENV_TERRAFORM_VERSION:-""}" ]; then
-  version_requested="${TFENV_TERRAFORM_VERSION}";
+elif [ "${#}" -eq 0 ] && [ -n "${TFENV_TERRAFORM_VERSION:-""}" ]; then
+  versions_to_uninstall+=("${TFENV_TERRAFORM_VERSION}");
   log 'debug' "TFENV_TERRAFORM_VERSION is set: ${TFENV_TERRAFORM_VERSION}";
 else
-  version_requested="${arg}";
+  versions_to_uninstall=("$@");
 fi;
 
-log 'debug' "Version Requested: ${version_requested}";
+[ "${#versions_to_uninstall[@]}" -gt 0 ] \
+  || log 'error' 'No versions specified for uninstall.';
 
-if [[ "${version_requested}" =~ ^min-required$ ]]; then
-  log 'error' 'min-required is an unsupported option for uninstall';
+declare -i fail_count=0;
+for ver in "${versions_to_uninstall[@]}"; do
+  # Run in subshell so log 'error' (which calls exit 1) does not kill the loop
+  (uninstall_single_version "${ver}") || ((fail_count++));
+done;
+
+# If no versions remain, remove the versions directory
+if [ -d "${TFENV_CONFIG_DIR}/versions" ]; then
+  rmdir "${TFENV_CONFIG_DIR}/versions" 2>/dev/null || true;
 fi;
 
-if [[ "${version_requested}" == latest-allowed ]]; then
-  log 'error' 'latest-allowed is an unsupported option for uninstall';
-fi;
-
-if [[ "${version_requested}" =~ ^latest\:.*$ ]]; then
-  version="${version_requested%%\:*}";
-  regex="${version_requested##*\:}";
-elif [[ "${version_requested}" =~ ^latest$ ]]; then
-  version="${version_requested}";
-  regex="";
-else
-  version="${version_requested}";
-  regex="^${version_requested}$";
-fi;
-
-[ -z "${version:-""}" ] && log 'error' "Version not specified on the command line or on version file search path.";
-
-log 'debug' "Processing uninstall for version ${version}, using regex ${regex}";
-
-version="$(tfenv-list | sed -E 's/^(\*| )? //g; s/ \(set by .+\)$//' | grep -e "${regex}" | head -n 1)";
-[ -n "${version}" ] || log 'error' "No versions matching '${regex}' found in local";
-
-dst_path="${TFENV_CONFIG_DIR}/versions/${version}";
-if [ -f "${dst_path}/terraform" ]; then
-  log 'info' "Uninstall Terraform v${version}";
-  rm -r "${dst_path}";
-
-  # If no versions remain, remove the versions directory
-  rmdir "${TFENV_CONFIG_DIR}/versions" 2>/dev/null;
-
-  log 'info' "Terraform v${version} is successfully uninstalled";
-fi;
+[ "${fail_count}" -eq 0 ] || exit 1;

--- a/test/test_uninstall.sh
+++ b/test/test_uninstall.sh
@@ -60,5 +60,22 @@ cleanup || error_and_proceed "Cleanup failed?!"
   [ -d "${TFENV_CONFIG_DIR}/versions" ] && exit 1 || exit 0
 ) || error_and_proceed "Removing last version deletes versions directory"
 
+log 'info' '### Multi-version uninstall';
+cleanup || log 'error' 'Cleanup failed?!';
+(
+  tfenv install 0.12.1 || exit 1;
+  tfenv install 0.12.2 || exit 1;
+  tfenv install 0.12.3 || exit 1;
+  # Uninstall multiple versions in one command
+  tfenv uninstall 0.12.1 0.12.3 || exit 1;
+  # 0.12.2 should still be present
+  [ -d "${TFENV_CONFIG_DIR}/versions/0.12.2" ] || { echo '0.12.2 should still exist'; exit 1; };
+  # 0.12.1 and 0.12.3 should be gone
+  [ -d "${TFENV_CONFIG_DIR}/versions/0.12.1" ] && { echo '0.12.1 should be removed'; exit 1; };
+  [ -d "${TFENV_CONFIG_DIR}/versions/0.12.3" ] && { echo '0.12.3 should be removed'; exit 1; };
+  exit 0;
+) && log 'info' '### Multi-version uninstall passed' \
+  || error_and_proceed 'Multi-version uninstall failed';
+
 finish_tests 'uninstall';
 exit 0;


### PR DESCRIPTION
tfenv uninstall now accepts multiple version arguments:

```bash
tfenv uninstall 1.5.0 1.6.0 1.7.0
```

Each version is processed independently in a subshell — if one fails, the remaining versions are still uninstalled and the command exits nonzero at the end.

**Changes:**
- `libexec/tfenv-uninstall`: Refactored into `uninstall_single_version()` function called in a loop. Accepts `$@` instead of single arg.
- `libexec/tfenv-help`: Updated usage description.
- `test/test_uninstall.sh`: New test case installs 3 versions, uninstalls 2 in one command, verifies the third remains.

**Backward compatible:** Single-version uninstall behaviour is unchanged. No-arg behaviour (version file / `TFENV_TERRAFORM_VERSION`) is unchanged.

Fixes #449