### PR TITLE
feat: show architecture in tfenv list output (#321)

### DIFF
--- a/libexec/tfenv-list
+++ b/libexec/tfenv-list
@@ -84,12 +84,31 @@ export version_source;
 # Register for whether a default terraform version has yet been set
 declare -i default_set=0;
 
+detect_arch() {
+  local binary="${1}";
+  if [ ! -f "${binary}" ]; then
+    echo 'unknown';
+    return;
+  fi;
+  local file_output;
+  file_output="$(file -b "${binary}" 2>/dev/null)" || { echo 'unknown'; return; };
+  case "${file_output}" in
+    *x86-64*|*x86_64*)  echo 'amd64';;
+    *aarch64*|*arm64*)   echo 'arm64';;
+    *386*|*i386*|*80386*) echo '386';;
+    *ARM,*)              echo 'arm';;
+    *)                   echo 'unknown';;
+  esac;
+};
+
 print_version () {
+  local arch;
+  arch="$(detect_arch "${TFENV_CONFIG_DIR}/versions/${1}/terraform")";
   if [ "${1}" == "${version_name}" ]; then
-    echo "* ${1} (set by ${version_source})";
+    echo "* ${1} (${arch}) (set by ${version_source})";
     default_set=1;
   else
-    echo "  ${1}";
+    echo "  ${1} (${arch})";
   fi;
 };
 

--- a/libexec/tfenv-uninstall
+++ b/libexec/tfenv-uninstall
@@ -112,7 +112,7 @@ fi;
 
 log 'debug' "Processing uninstall for version ${version}, using regex ${regex}";
 
-version="$(tfenv-list | sed -E 's/^(\*| )? //g; s/ \(set by .+\)$//' | grep -e "${regex}" | head -n 1)";
+version="$(tfenv-list | sed -E 's/^(\*| )? //g; s/ \([^)]+\)//g' | grep -e "${regex}" | head -n 1)";
 [ -n "${version}" ] || log 'error' "No versions matching '${regex}' found in local";
 
 dst_path="${TFENV_CONFIG_DIR}/versions/${version}";

--- a/test/test_list.sh
+++ b/test/test_list.sh
@@ -29,21 +29,28 @@ tfenv use 0.14.6;
 log 'info' '## Comparing "tfenv list" with default set';
 result="$(tfenv list)";
 
-# Determine expected arch from host platform
-case "$(uname -m)" in
-  x86_64)       expected_arch='amd64';;
-  aarch64|arm64) expected_arch='arm64';;
-  i386|i686)    expected_arch='386';;
-  *)            expected_arch='unknown';;
-esac;
+# Detect arch from each installed binary — can't assume host arch
+# because older versions may only have amd64 builds (e.g. macOS arm64 via Rosetta)
+detect_arch() {
+  local binary="${1}";
+  local file_output;
+  file_output="$(file -b "${binary}" 2>/dev/null)" || { echo 'unknown'; return; };
+  case "${file_output}" in
+    *x86-64*|*x86_64*)  echo 'amd64';;
+    *aarch64*|*arm64*)   echo 'arm64';;
+    *386*|*i386*|*80386*) echo '386';;
+    *ARM,*)              echo 'arm';;
+    *)                   echo 'unknown';;
+  esac;
+};
 
 expected="$(cat << EOS
-* 0.14.6 (${expected_arch}) (set by $(tfenv version-file))
-  0.9.11 (${expected_arch})
-  0.9.2 (${expected_arch})
-  0.9.1 (${expected_arch})
-  0.7.13 (${expected_arch})
-  0.7.2 (${expected_arch})
+* 0.14.6 ($(detect_arch "${TFENV_CONFIG_DIR}/versions/0.14.6/terraform")) (set by $(tfenv version-file))
+  0.9.11 ($(detect_arch "${TFENV_CONFIG_DIR}/versions/0.9.11/terraform"))
+  0.9.2 ($(detect_arch "${TFENV_CONFIG_DIR}/versions/0.9.2/terraform"))
+  0.9.1 ($(detect_arch "${TFENV_CONFIG_DIR}/versions/0.9.1/terraform"))
+  0.7.13 ($(detect_arch "${TFENV_CONFIG_DIR}/versions/0.7.13/terraform"))
+  0.7.2 ($(detect_arch "${TFENV_CONFIG_DIR}/versions/0.7.2/terraform"))
 EOS
 )";
 

--- a/test/test_list.sh
+++ b/test/test_list.sh
@@ -28,13 +28,22 @@ tfenv use 0.14.6;
 
 log 'info' '## Comparing "tfenv list" with default set';
 result="$(tfenv list)";
+
+# Determine expected arch from host platform
+case "$(uname -m)" in
+  x86_64)       expected_arch='amd64';;
+  aarch64|arm64) expected_arch='arm64';;
+  i386|i686)    expected_arch='386';;
+  *)            expected_arch='unknown';;
+esac;
+
 expected="$(cat << EOS
-* 0.14.6 (set by $(tfenv version-file))
-  0.9.11
-  0.9.2
-  0.9.1
-  0.7.13
-  0.7.2
+* 0.14.6 (${expected_arch}) (set by $(tfenv version-file))
+  0.9.11 (${expected_arch})
+  0.9.2 (${expected_arch})
+  0.9.1 (${expected_arch})
+  0.7.13 (${expected_arch})
+  0.7.2 (${expected_arch})
 EOS
 )";
 


### PR DESCRIPTION
tfenv list now displays the architecture of each installed terraform binary:

```
* 1.5.0 (amd64) (set by /home/user/.terraform-version)
  1.4.0 (arm64)
  1.3.0 (amd64)
```

Architecture is detected from the terraform binary using the `file` command. Supported architectures: `amd64`, `arm64`, `386`, `arm`. Falls back to `unknown` if detection fails.

**Changes:**
- `libexec/tfenv-list`: Added `detect_arch()` function using `file -b` to inspect the binary. Updated `print_version()` to include arch.
- `libexec/tfenv-uninstall`: Updated sed pattern to strip parenthesized groups (arch + set-by) when parsing list output.
- `test/test_list.sh`: Updated expected output to include arch, dynamically detected from `uname -m` for cross-platform CI compatibility.

**Note:** This PR will have a minor merge conflict with #481 (multi-version uninstall) on the sed pattern in `tfenv-uninstall`. Both change the same line — resolution is to use the `s/ \([^)]+\)//g` pattern in the refactored `uninstall_single_version()` function.

Fixes #321