### PR TITLE
Release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.2.0 (April 24, 2026)
+
+ * NEW FEATURE: Support comments in `.terraform-version` files — lines starting with `#` and inline `#` comments are stripped, fixing #391 and #283 (Mike Peachey <mike.peachey@bjss.com>)
+ * NEW FEATURE: Support uninstalling multiple versions in a single `tfenv uninstall` invocation, fixing #449 (Mike Peachey <mike.peachey@bjss.com>)
+ * NEW FEATURE: Show binary architecture in `tfenv list` output (e.g. `amd64`, `arm64`), fixing #321 (Mike Peachey <mike.peachey@bjss.com>)
+ * NEW FEATURE: Support `tfenv use -` to switch to the previously active version, fixing #378 (Mike Peachey <mike.peachey@bjss.com>)
+
 ## 3.1.0 (April 24, 2026)
 
  * NEW FEATURE: Add `latest-allowed` version resolution from `required_version` constraint in Terraform files, supporting `=`, `>=`, `>`, `<=`, and `~>` operators (Oliver Ford <dev@ojford.com>, Mike Peachey <mike.peachey@bjss.com>)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache --purge \
     curl \
     ;
 
-ARG TFENV_VERSION=3.2.0
+ARG TFENV_VERSION=3.1.0
 RUN wget -O /tmp/tfenv.tar.gz "https://github.com/tfutils/tfenv/archive/refs/tags/v${TFENV_VERSION}.tar.gz" \
     && tar -C /tmp -xf /tmp/tfenv.tar.gz \
     && mv "/tmp/tfenv-${TFENV_VERSION}/bin"/* /usr/local/bin/ \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache --purge \
     curl \
     ;
 
-ARG TFENV_VERSION=3.1.0
+ARG TFENV_VERSION=3.2.0
 RUN wget -O /tmp/tfenv.tar.gz "https://github.com/tfutils/tfenv/archive/refs/tags/v${TFENV_VERSION}.tar.gz" \
     && tar -C /tmp -xf /tmp/tfenv.tar.gz \
     && mv "/tmp/tfenv-${TFENV_VERSION}/bin"/* /usr/local/bin/ \


### PR DESCRIPTION
Update CHANGELOG.md and Dockerfile for v3.2.0 release.

## Changes in v3.2.0

- **NEW FEATURE:** Comments in `.terraform-version` files (#391, #283)
- **NEW FEATURE:** Multi-version uninstall (#449)
- **NEW FEATURE:** Show architecture in `tfenv list` output (#321)
- **NEW FEATURE:** `tfenv use -` to switch to previous version (#378)