### PR TITLE
chore: bump Dockerfile to v3.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache --purge \
     curl \
     ;
 
-ARG TFENV_VERSION=3.1.0
+ARG TFENV_VERSION=3.2.0
 RUN wget -O /tmp/tfenv.tar.gz "https://github.com/tfutils/tfenv/archive/refs/tags/v${TFENV_VERSION}.tar.gz" \
     && tar -C /tmp -xf /tmp/tfenv.tar.gz \
     && mv "/tmp/tfenv-${TFENV_VERSION}/bin"/* /usr/local/bin/ \


### PR DESCRIPTION
Bump `TFENV_VERSION` in Dockerfile to `3.2.0` now that the tag exists.