### PR TITLE
feat: Go edition scaffolding, CLI framework & multi-call entry point

### DIFF
--- a/go/cmd/tfenv/main.go
+++ b/go/cmd/tfenv/main.go
@@ -1,0 +1,32 @@
+// Package main provides the multi-call entry point for the tfenv Go edition.
+//
+// When invoked as "tfenv", it dispatches to the CLI subcommand handler.
+// When invoked as "terraform" (e.g. via symlink), it delegates to the shim.
+//
+// Multi-call detection uses the raw basename of os.Args[0] (before symlink
+// resolution). A symlink named "terraform" → "tfenv" will see "terraform"
+// as the basename and route to the shim.
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/tfutils/tfenv/go/internal/cli"
+	"github.com/tfutils/tfenv/go/internal/shim"
+)
+
+// version is set at build time via -ldflags "-X main.version=...".
+// It defaults to "dev" for local builds.
+var version = "dev"
+
+func main() {
+	basename := filepath.Base(os.Args[0])
+
+	switch basename {
+	case "terraform":
+		os.Exit(shim.Run(os.Args[1:]))
+	default:
+		os.Exit(cli.Run(version, os.Args[1:]))
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/tfutils/tfenv/go
+
+go 1.24

--- a/go/internal/cli/cli.go
+++ b/go/internal/cli/cli.go
@@ -1,0 +1,111 @@
+// Package cli provides the command dispatch framework for tfenv.
+//
+// Subcommands are registered in a map of name to handler function.
+// Other packages plug in by adding entries to the registry.
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// Handler is the function signature for a subcommand handler.
+// It receives the remaining command-line arguments and returns an exit code.
+type Handler func(args []string) int
+
+// command holds metadata for a registered subcommand.
+type command struct {
+	handler     Handler
+	description string
+}
+
+// registry maps subcommand names to their handlers and descriptions.
+var registry = map[string]command{}
+
+// Register adds a subcommand to the dispatch registry.
+func Register(name string, description string, handler Handler) {
+	registry[name] = command{
+		handler:     handler,
+		description: description,
+	}
+}
+
+// Run dispatches to the appropriate subcommand based on args.
+// It returns an exit code suitable for os.Exit.
+func Run(version string, args []string) int {
+	if len(args) == 0 {
+		printUsage(version)
+		return 0
+	}
+
+	subcmd := args[0]
+
+	// Handle --version and version as special cases.
+	if subcmd == "--version" || subcmd == "version" {
+		fmt.Fprintf(os.Stdout, "tfenv %s\n", version)
+		return 0
+	}
+
+	// Handle help as a special case.
+	if subcmd == "help" || subcmd == "--help" || subcmd == "-h" {
+		printUsage(version)
+		return 0
+	}
+
+	// Look up the subcommand in the registry.
+	cmd, ok := registry[subcmd]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "tfenv: unknown command %q\n", subcmd)
+		fmt.Fprintf(os.Stderr, "Run 'tfenv help' for usage.\n")
+		return 1
+	}
+
+	return cmd.handler(args[1:])
+}
+
+// printUsage prints the help text listing all registered subcommands.
+func printUsage(version string) {
+	fmt.Fprintf(os.Stdout, "tfenv %s\n\n", version)
+	fmt.Fprintf(os.Stdout, "Usage: tfenv <command> [args]\n\n")
+
+	// Always include the built-in commands.
+	builtins := []struct {
+		name string
+		desc string
+	}{
+		{"help", "Show this help output"},
+		{"version", "Print tfenv version"},
+	}
+
+	// Collect registered commands and sort them.
+	var names []string
+	for name := range registry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	fmt.Fprintf(os.Stdout, "Commands:\n")
+
+	// Print built-in commands first.
+	for _, b := range builtins {
+		fmt.Fprintf(os.Stdout, "  %-16s %s\n", b.name, b.desc)
+	}
+
+	// Print registered commands.
+	for _, name := range names {
+		cmd := registry[name]
+		fmt.Fprintf(os.Stdout, "  %-16s %s\n", name, cmd.description)
+	}
+
+	// Build the full list for "Available commands" summary.
+	var all []string
+	for _, b := range builtins {
+		all = append(all, b.name)
+	}
+	all = append(all, names...)
+	sort.Strings(all)
+
+	fmt.Fprintf(os.Stdout, "\nAvailable commands: %s\n", strings.Join(all, ", "))
+}

--- a/go/internal/cli/cli_test.go
+++ b/go/internal/cli/cli_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestRunVersion(t *testing.T) {
+	exit := Run("1.2.3", []string{"--version"})
+	if exit != 0 {
+		t.Errorf("expected exit code 0, got %d", exit)
+	}
+}
+
+func TestRunVersionSubcommand(t *testing.T) {
+	exit := Run("1.2.3", []string{"version"})
+	if exit != 0 {
+		t.Errorf("expected exit code 0, got %d", exit)
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	exit := Run("1.2.3", []string{"help"})
+	if exit != 0 {
+		t.Errorf("expected exit code 0, got %d", exit)
+	}
+}
+
+func TestRunNoArgs(t *testing.T) {
+	exit := Run("1.2.3", []string{})
+	if exit != 0 {
+		t.Errorf("expected exit code 0, got %d", exit)
+	}
+}
+
+func TestRunUnknownCommand(t *testing.T) {
+	exit := Run("1.2.3", []string{"unknown-command"})
+	if exit != 1 {
+		t.Errorf("expected exit code 1, got %d", exit)
+	}
+}
+
+func TestRegisterAndRun(t *testing.T) {
+	Register("test-cmd", "A test command", func(args []string) int {
+		return 0
+	})
+	defer func() {
+		delete(registry, "test-cmd")
+	}()
+
+	exit := Run("1.2.3", []string{"test-cmd"})
+	if exit != 0 {
+		t.Errorf("expected exit code 0, got %d", exit)
+	}
+}

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -1,0 +1,2 @@
+// Package config handles environment variable loading and state directory resolution.
+package config

--- a/go/internal/install/install.go
+++ b/go/internal/install/install.go
@@ -1,0 +1,2 @@
+// Package install implements Terraform binary download, verification, and installation.
+package install

--- a/go/internal/list/list.go
+++ b/go/internal/list/list.go
@@ -1,0 +1,2 @@
+// Package list provides local and remote Terraform version listing.
+package list

--- a/go/internal/logging/logging.go
+++ b/go/internal/logging/logging.go
@@ -1,0 +1,2 @@
+// Package logging provides structured logging for the tfenv Go edition.
+package logging

--- a/go/internal/platform/platform.go
+++ b/go/internal/platform/platform.go
@@ -1,0 +1,2 @@
+// Package platform detects the current OS, architecture, and platform-specific behaviour.
+package platform

--- a/go/internal/resolve/resolve.go
+++ b/go/internal/resolve/resolve.go
@@ -1,0 +1,2 @@
+// Package resolve implements .terraform-version file discovery and version constraint resolution.
+package resolve

--- a/go/internal/shim/shim.go
+++ b/go/internal/shim/shim.go
@@ -1,0 +1,15 @@
+// Package shim implements the Terraform shim, intercepting calls to the
+// terraform binary and delegating to the correct installed version.
+package shim
+
+import (
+	"fmt"
+	"os"
+)
+
+// Run is the entry point for the terraform shim.
+// It is invoked when the binary is called as "terraform" via symlink.
+func Run(args []string) int {
+	fmt.Fprintf(os.Stderr, "terraform shim not yet implemented\n")
+	return 1
+}

--- a/go/internal/shim/shim_test.go
+++ b/go/internal/shim/shim_test.go
@@ -1,0 +1,12 @@
+package shim
+
+import (
+	"testing"
+)
+
+func TestRunReturnsOne(t *testing.T) {
+	exit := Run([]string{"version"})
+	if exit != 1 {
+		t.Errorf("expected exit code 1 (stub not implemented), got %d", exit)
+	}
+}


### PR DESCRIPTION
Implements #489 — Go module scaffolding, CLI framework, and multi-call entry point.

## Changes
- Go module at `go/` with `github.com/tfutils/tfenv/go` module path
- Multi-call binary entry point (`tfenv` / `terraform` shim detection)
- CLI dispatch framework with subcommand registration pattern
- `help` and `--version` subcommands
- Stub packages for all internal packages
- Zero external dependencies

## Testing
- `go build ./cmd/tfenv` — builds cleanly
- `go vet ./...` — passes
- `go test ./...` — passes
- Manual verification of all CLI entry points

Closes #489