### PR TITLE
[STACKED] feat: acceptance test framework & mock release server

### DIFF
--- a/go/cmd/tfenv/main.go
+++ b/go/cmd/tfenv/main.go
@@ -1,0 +1,32 @@
+// Package main provides the multi-call entry point for the tfenv Go edition.
+//
+// When invoked as "tfenv", it dispatches to the CLI subcommand handler.
+// When invoked as "terraform" (e.g. via symlink), it delegates to the shim.
+//
+// Multi-call detection uses the raw basename of os.Args[0] (before symlink
+// resolution). A symlink named "terraform" → "tfenv" will see "terraform"
+// as the basename and route to the shim.
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/tfutils/tfenv/go/internal/cli"
+	"github.com/tfutils/tfenv/go/internal/shim"
+)
+
+// version is set at build time via -ldflags "-X main.version=...".
+// It defaults to "dev" for local builds.
+var version = "dev"
+
+func main() {
+	basename := filepath.Base(os.Args[0])
+
+	switch basename {
+	case "terraform":
+		os.Exit(shim.Run(os.Args[1:]))
+	default:
+		os.Exit(cli.Run(version, os.Args[1:]))
+	}
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/tfutils/tfenv/go
+
+go 1.24

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,3 +1,5 @@
 module github.com/tfutils/tfenv/go
 
-go 1.24
+go 1.25.0
+
+require golang.org/x/crypto v0.50.0

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,0 +1,2 @@
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=

--- a/go/internal/cli/cli.go
+++ b/go/internal/cli/cli.go
@@ -1,0 +1,111 @@
+// Package cli provides the command dispatch framework for tfenv.
+//
+// Subcommands are registered in a map of name to handler function.
+// Other packages plug in by adding entries to the registry.
+package cli
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+)
+
+// Handler is the function signature for a subcommand handler.
+// It receives the remaining command-line arguments and returns an exit code.
+type Handler func(args []string) int
+
+// command holds metadata for a registered subcommand.
+type command struct {
+	handler     Handler
+	description string
+}
+
+// registry maps subcommand names to their handlers and descriptions.
+var registry = map[string]command{}
+
+// Register adds a subcommand to the dispatch registry.
+func Register(name string, description string, handler Handler) {
+	registry[name] = command{
+		handler:     handler,
+		description: description,
+	}
+}
+
+// Run dispatches to the appropriate subcommand based on args.
+// It returns an exit code suitable for os.Exit.
+func Run(version string, args []string) int {
+	if len(args) == 0 {
+		printUsage(version)
+		return 0
+	}
+
+	subcmd := args[0]
+
+	// Handle --version and version as special cases.
+	if subcmd == "--version" || subcmd == "version" {
+		fmt.Fprintf(os.Stdout, "tfenv %s\n", version)
+		return 0
+	}
+
+	// Handle help as a special case.
+	if subcmd == "help" || subcmd == "--help" || subcmd == "-h" {
+		printUsage(version)
+		return 0
+	}
+
+	// Look up the subcommand in the registry.
+	cmd, ok := registry[subcmd]
+	if !ok {
+		fmt.Fprintf(os.Stderr, "tfenv: unknown command %q\n", subcmd)
+		fmt.Fprintf(os.Stderr, "Run 'tfenv help' for usage.\n")
+		return 1
+	}
+
+	return cmd.handler(args[1:])
+}
+
+// printUsage prints the help text listing all registered subcommands.
+func printUsage(version string) {
+	fmt.Fprintf(os.Stdout, "tfenv %s\n\n", version)
+	fmt.Fprintf(os.Stdout, "Usage: tfenv <command> [args]\n\n")
+
+	// Always include the built-in commands.
+	builtins := []struct {
+		name string
+		desc string
+	}{
+		{"help", "Show this help output"},
+		{"version", "Print tfenv version"},
+	}
+
+	// Collect registered commands and sort them.
+	var names []string
+	for name := range registry {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	fmt.Fprintf(os.Stdout, "Commands:\n")
+
+	// Print built-in commands first.
+	for _, b := range builtins {
+		fmt.Fprintf(os.Stdout, "  %-16s %s\n", b.name, b.desc)
+	}
+
+	// Print registered commands.
+	for _, name := range names {
+		cmd := registry[name]
+		fmt.Fprintf(os.Stdout, "  %-16s %s\n", name, cmd.description)
+	}
+
+	// Build the full list for "Available commands" summary.
+	var all []string
+	for _, b := range builtins {
+		all = append(all, b.name)
+	}
+	all = append(all, names...)
+	sort.Strings(all)
+
+	fmt.Fprintf(os.Stdout, "\nAvailable commands: %s\n", strings.Join(all, ", "))
+}

--- a/go/internal/cli/cli_test.go
+++ b/go/internal/cli/cli_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"testing"
+)
+
+func TestRunVersion(t *testing.T) {
+	exit := Run("1.2.3", []string{"--version"})
+	if exit != 0 {
+		t.Errorf("expected exit code 0, got %d", exit)
+	}
+}
+
+func TestRunVersionSubcommand(t *testing.T) {
+	exit := Run("1.2.3", []string{"version"})
+	if exit != 0 {
+		t.Errorf("expected exit code 0, got %d", exit)
+	}
+}
+
+func TestRunHelp(t *testing.T) {
+	exit := Run("1.2.3", []string{"help"})
+	if exit != 0 {
+		t.Errorf("expected exit code 0, got %d", exit)
+	}
+}
+
+func TestRunNoArgs(t *testing.T) {
+	exit := Run("1.2.3", []string{})
+	if exit != 0 {
+		t.Errorf("expected exit code 0, got %d", exit)
+	}
+}
+
+func TestRunUnknownCommand(t *testing.T) {
+	exit := Run("1.2.3", []string{"unknown-command"})
+	if exit != 1 {
+		t.Errorf("expected exit code 1, got %d", exit)
+	}
+}
+
+func TestRegisterAndRun(t *testing.T) {
+	Register("test-cmd", "A test command", func(args []string) int {
+		return 0
+	})
+	defer func() {
+		delete(registry, "test-cmd")
+	}()
+
+	exit := Run("1.2.3", []string{"test-cmd"})
+	if exit != 0 {
+		t.Errorf("expected exit code 0, got %d", exit)
+	}
+}

--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -1,0 +1,2 @@
+// Package config handles environment variable loading and state directory resolution.
+package config

--- a/go/internal/install/install.go
+++ b/go/internal/install/install.go
@@ -1,0 +1,2 @@
+// Package install implements Terraform binary download, verification, and installation.
+package install

--- a/go/internal/list/list.go
+++ b/go/internal/list/list.go
@@ -1,0 +1,2 @@
+// Package list provides local and remote Terraform version listing.
+package list

--- a/go/internal/logging/logging.go
+++ b/go/internal/logging/logging.go
@@ -1,0 +1,2 @@
+// Package logging provides structured logging for the tfenv Go edition.
+package logging

--- a/go/internal/platform/platform.go
+++ b/go/internal/platform/platform.go
@@ -1,0 +1,2 @@
+// Package platform detects the current OS, architecture, and platform-specific behaviour.
+package platform

--- a/go/internal/resolve/resolve.go
+++ b/go/internal/resolve/resolve.go
@@ -1,0 +1,2 @@
+// Package resolve implements .terraform-version file discovery and version constraint resolution.
+package resolve

--- a/go/internal/shim/shim.go
+++ b/go/internal/shim/shim.go
@@ -1,0 +1,15 @@
+// Package shim implements the Terraform shim, intercepting calls to the
+// terraform binary and delegating to the correct installed version.
+package shim
+
+import (
+	"fmt"
+	"os"
+)
+
+// Run is the entry point for the terraform shim.
+// It is invoked when the binary is called as "terraform" via symlink.
+func Run(args []string) int {
+	fmt.Fprintf(os.Stderr, "terraform shim not yet implemented\n")
+	return 1
+}

--- a/go/internal/shim/shim_test.go
+++ b/go/internal/shim/shim_test.go
@@ -1,0 +1,12 @@
+package shim
+
+import (
+	"testing"
+)
+
+func TestRunReturnsOne(t *testing.T) {
+	exit := Run([]string{"version"})
+	if exit != 1 {
+		t.Errorf("expected exit code 1 (stub not implemented), got %d", exit)
+	}
+}

--- a/go/test/acceptance/acceptance_test.go
+++ b/go/test/acceptance/acceptance_test.go
@@ -1,0 +1,25 @@
+// Package acceptance provides shared acceptance test infrastructure for tfenv.
+//
+// Tests invoke whichever binary TFENV_TEST_BINARY points to, enabling parity
+// testing between the Bash and Go editions.
+package acceptance
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// tfenvBinary holds the path to the tfenv binary under test.
+// It is set once in TestMain from the TFENV_TEST_BINARY env var.
+var tfenvBinary string
+
+func TestMain(m *testing.M) {
+	tfenvBinary = os.Getenv("TFENV_TEST_BINARY")
+	if tfenvBinary == "" {
+		fmt.Println("TFENV_TEST_BINARY not set — skipping acceptance tests")
+		fmt.Println("To run: TFENV_TEST_BINARY=/path/to/binary go test ./test/acceptance/... -v")
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}

--- a/go/test/acceptance/helpers_test.go
+++ b/go/test/acceptance/helpers_test.go
@@ -1,0 +1,125 @@
+package acceptance
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// runTfenv executes the tfenv binary under test with the given arguments.
+// It returns stdout, stderr, and the exit code. The test is NOT failed on
+// non-zero exit — callers decide whether that is expected.
+func runTfenv(t *testing.T, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+
+	cmd := exec.Command(tfenvBinary, args...)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	// Provide a clean environment with only essentials.
+	cmd.Env = cleanEnv(t)
+
+	err := cmd.Run()
+	exitCode = 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("failed to run %s: %v", tfenvBinary, err)
+		}
+	}
+
+	return outBuf.String(), errBuf.String(), exitCode
+}
+
+// runTfenvWithEnv executes the tfenv binary with additional environment
+// variables on top of the clean environment.
+func runTfenvWithEnv(t *testing.T, env map[string]string, args ...string) (stdout, stderr string, exitCode int) {
+	t.Helper()
+
+	cmd := exec.Command(tfenvBinary, args...)
+
+	var outBuf, errBuf bytes.Buffer
+	cmd.Stdout = &outBuf
+	cmd.Stderr = &errBuf
+
+	baseEnv := cleanEnv(t)
+	for k, v := range env {
+		baseEnv = append(baseEnv, k+"="+v)
+	}
+	cmd.Env = baseEnv
+
+	err := cmd.Run()
+	exitCode = 0
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			exitCode = exitErr.ExitCode()
+		} else {
+			t.Fatalf("failed to run %s: %v", tfenvBinary, err)
+		}
+	}
+
+	return outBuf.String(), errBuf.String(), exitCode
+}
+
+// cleanEnv returns a minimal environment slice suitable for running the
+// binary under test in isolation.
+func cleanEnv(t *testing.T) []string {
+	t.Helper()
+	return []string{
+		"PATH=" + filepath.Dir(tfenvBinary) + ":" + os.Getenv("PATH"),
+		"HOME=" + t.TempDir(),
+	}
+}
+
+// setupTempHome creates an isolated directory tree suitable for use as
+// the TFENV_CONFIG_DIR. It returns the path to the root.
+func setupTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	// Pre-create the versions directory so install tests have a target.
+	versionsDir := filepath.Join(dir, "versions")
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatalf("failed to create versions dir: %v", err)
+	}
+
+	return dir
+}
+
+// assertExitCode fails the test if got != want.
+func assertExitCode(t *testing.T, got, want int) {
+	t.Helper()
+	if got != want {
+		t.Errorf("exit code: got %d, want %d", got, want)
+	}
+}
+
+// assertOutputContains fails the test if output does not contain substring.
+func assertOutputContains(t *testing.T, output, substring string) {
+	t.Helper()
+	if !strings.Contains(output, substring) {
+		t.Errorf("expected output to contain %q, got:\n%s", substring, output)
+	}
+}
+
+// assertOutputNotContains fails the test if output contains substring.
+func assertOutputNotContains(t *testing.T, output, substring string) {
+	t.Helper()
+	if strings.Contains(output, substring) {
+		t.Errorf("expected output NOT to contain %q, got:\n%s", substring, output)
+	}
+}
+
+// assertFileExists fails the test if the path does not exist.
+func assertFileExists(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		t.Errorf("expected file to exist: %s", path)
+	}
+}

--- a/go/test/acceptance/integration_test.go
+++ b/go/test/acceptance/integration_test.go
@@ -1,0 +1,16 @@
+//go:build integration
+
+// Package acceptance_integration contains integration tests that hit the real
+// releases.hashicorp.com. These are excluded from the default test run and
+// must be opted into via: go test -tags integration ./test/acceptance/...
+//
+// These tests require network access and are slow — they download real
+// Terraform binaries.
+package acceptance
+
+// Integration tests will be added here as commands are implemented.
+// Example:
+//
+//   func TestInstallRealBinary(t *testing.T) {
+//       // Download and verify a real Terraform release.
+//   }

--- a/go/test/acceptance/mock_server_test.go
+++ b/go/test/acceptance/mock_server_test.go
@@ -1,0 +1,312 @@
+package acceptance
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/openpgp"
+	"golang.org/x/crypto/openpgp/armor"
+	"golang.org/x/crypto/openpgp/packet"
+)
+
+// MockRelease describes a single Terraform version served by the mock server.
+type MockRelease struct {
+	Version   string
+	Platforms []MockPlatform
+}
+
+// MockPlatform describes an os/arch combination for a release.
+type MockPlatform struct {
+	OS   string
+	Arch string
+}
+
+// MockServer wraps an httptest.Server and exposes the test PGP key for
+// verification testing.
+type MockServer struct {
+	Server       *httptest.Server
+	URL          string
+	PGPEntity    *openpgp.Entity
+	ArmoredPubKey string
+}
+
+// Close shuts down the mock server.
+func (m *MockServer) Close() {
+	m.Server.Close()
+}
+
+// defaultMockReleases returns a set of fake versions covering common test
+// scenarios: multiple minor versions, patch levels, and a pre-release.
+func defaultMockReleases() []MockRelease {
+	os := runtime.GOOS
+	arch := runtime.GOARCH
+	return []MockRelease{
+		{Version: "1.6.1", Platforms: []MockPlatform{{OS: os, Arch: arch}}},
+		{Version: "1.6.0", Platforms: []MockPlatform{{OS: os, Arch: arch}}},
+		{Version: "1.5.7", Platforms: []MockPlatform{{OS: os, Arch: arch}}},
+		{Version: "1.5.7-rc1", Platforms: []MockPlatform{{OS: os, Arch: arch}}},
+		{Version: "1.5.6", Platforms: []MockPlatform{{OS: os, Arch: arch}}},
+		{Version: "1.4.0", Platforms: []MockPlatform{{OS: os, Arch: arch}}},
+	}
+}
+
+// startMockReleaseServer creates and starts an httptest.Server serving mock
+// HashiCorp-style release artifacts. The server is automatically closed via
+// t.Cleanup.
+func startMockReleaseServer(t *testing.T) *MockServer {
+	t.Helper()
+
+	releases := defaultMockReleases()
+	entity := generateTestPGPKey(t)
+
+	armoredPub := armorPublicKey(t, entity)
+
+	mux := http.NewServeMux()
+
+	// Version index at /terraform/ — HTML with links like the real
+	// releases.hashicorp.com page.
+	mux.HandleFunc("/terraform/", func(w http.ResponseWriter, r *http.Request) {
+		// If the path has more segments, it's a per-version directory request.
+		trimmed := strings.TrimPrefix(r.URL.Path, "/terraform/")
+		trimmed = strings.TrimSuffix(trimmed, "/")
+
+		if trimmed == "" {
+			// Root index page.
+			serveVersionIndex(w, releases)
+			return
+		}
+
+		// Try to match version/filename.
+		parts := strings.SplitN(trimmed, "/", 2)
+		version := parts[0]
+		var release *MockRelease
+		for i := range releases {
+			if releases[i].Version == version {
+				release = &releases[i]
+				break
+			}
+		}
+		if release == nil {
+			http.NotFound(w, r)
+			return
+		}
+
+		if len(parts) == 1 {
+			// Version directory listing — not strictly needed but helpful.
+			serveVersionDirectory(w, *release)
+			return
+		}
+
+		filename := parts[1]
+		serveReleaseArtifact(t, w, r, *release, filename, entity)
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	return &MockServer{
+		Server:        server,
+		URL:           server.URL,
+		PGPEntity:     entity,
+		ArmoredPubKey: armoredPub,
+	}
+}
+
+// serveVersionIndex writes an HTML page with links to each version, matching
+// the format found on releases.hashicorp.com/terraform/.
+func serveVersionIndex(w http.ResponseWriter, releases []MockRelease) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	var buf bytes.Buffer
+	buf.WriteString("<html><body>\n")
+	for _, r := range releases {
+		fmt.Fprintf(&buf, "<a href=\"/terraform/%s/\">terraform_%s</a>\n", r.Version, r.Version)
+	}
+	buf.WriteString("</body></html>\n")
+	w.Write(buf.Bytes())
+}
+
+// serveVersionDirectory writes an HTML page listing artifacts for a version.
+func serveVersionDirectory(w http.ResponseWriter, release MockRelease) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	var buf bytes.Buffer
+	buf.WriteString("<html><body>\n")
+	prefix := "terraform_" + release.Version
+	for _, p := range release.Platforms {
+		name := fmt.Sprintf("%s_%s_%s.zip", prefix, p.OS, p.Arch)
+		fmt.Fprintf(&buf, "<a href=\"%s\">%s</a>\n", name, name)
+	}
+	fmt.Fprintf(&buf, "<a href=\"%s_SHA256SUMS\">%s_SHA256SUMS</a>\n", prefix, prefix)
+	fmt.Fprintf(&buf, "<a href=\"%s_SHA256SUMS.72D7468F.sig\">%s_SHA256SUMS.72D7468F.sig</a>\n", prefix, prefix)
+	buf.WriteString("</body></html>\n")
+	w.Write(buf.Bytes())
+}
+
+// serveReleaseArtifact serves an individual file from a version directory.
+func serveReleaseArtifact(t *testing.T, w http.ResponseWriter, r *http.Request, release MockRelease, filename string, entity *openpgp.Entity) {
+	t.Helper()
+	prefix := "terraform_" + release.Version
+
+	switch {
+	case filename == prefix+"_SHA256SUMS":
+		serveSHA256SUMS(t, w, release)
+	case filename == prefix+"_SHA256SUMS.72D7468F.sig":
+		serveSHA256SUMSSig(t, w, release, entity)
+	case strings.HasSuffix(filename, ".zip"):
+		serveZip(t, w, release, filename)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// serveSHA256SUMS generates and serves the SHA256SUMS file for a release.
+func serveSHA256SUMS(t *testing.T, w http.ResponseWriter, release MockRelease) {
+	t.Helper()
+	content := buildSHA256SUMS(t, release)
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Write([]byte(content))
+}
+
+// serveSHA256SUMSSig generates and serves a PGP detached signature of the
+// SHA256SUMS file.
+func serveSHA256SUMSSig(t *testing.T, w http.ResponseWriter, release MockRelease, entity *openpgp.Entity) {
+	t.Helper()
+	content := buildSHA256SUMS(t, release)
+
+	var sigBuf bytes.Buffer
+	err := openpgp.DetachSign(&sigBuf, entity, strings.NewReader(content), &packet.Config{
+		DefaultHash: crypto.SHA256,
+	})
+	if err != nil {
+		t.Fatalf("failed to create detached signature: %v", err)
+	}
+
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Write(sigBuf.Bytes())
+}
+
+// serveZip serves a zip archive containing a stub terraform binary.
+func serveZip(t *testing.T, w http.ResponseWriter, release MockRelease, filename string) {
+	t.Helper()
+
+	// Parse platform from filename: terraform_VERSION_OS_ARCH.zip
+	prefix := "terraform_" + release.Version + "_"
+	suffix := ".zip"
+	if !strings.HasPrefix(filename, prefix) || !strings.HasSuffix(filename, suffix) {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
+
+	zipContent := buildZip(t, release.Version)
+	w.Header().Set("Content-Type", "application/zip")
+	w.Write(zipContent)
+}
+
+// buildZip creates a zip archive containing a stub terraform script that
+// prints "Terraform vVERSION" when executed.
+func buildZip(t *testing.T, version string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+
+	// Create a stub shell script as the "terraform" binary.
+	stub := fmt.Sprintf("#!/bin/sh\necho \"Terraform v%s\"\n", version)
+
+	header := &zip.FileHeader{
+		Name:   "terraform",
+		Method: zip.Deflate,
+	}
+	// Set executable permissions.
+	header.SetMode(0o755)
+
+	fw, err := zw.CreateHeader(header)
+	if err != nil {
+		t.Fatalf("failed to create zip entry: %v", err)
+	}
+	if _, err := fw.Write([]byte(stub)); err != nil {
+		t.Fatalf("failed to write zip entry: %v", err)
+	}
+
+	if err := zw.Close(); err != nil {
+		t.Fatalf("failed to close zip writer: %v", err)
+	}
+
+	return buf.Bytes()
+}
+
+// buildSHA256SUMS generates the SHA256SUMS content for a release. Each line
+// has the format "hash  filename".
+func buildSHA256SUMS(t *testing.T, release MockRelease) string {
+	t.Helper()
+
+	// Collect entries sorted by filename for deterministic output.
+	type entry struct {
+		hash     string
+		filename string
+	}
+	var entries []entry
+
+	for _, p := range release.Platforms {
+		zipData := buildZip(t, release.Version)
+		h := sha256.Sum256(zipData)
+		filename := fmt.Sprintf("terraform_%s_%s_%s.zip", release.Version, p.OS, p.Arch)
+		entries = append(entries, entry{
+			hash:     fmt.Sprintf("%x", h),
+			filename: filename,
+		})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].filename < entries[j].filename
+	})
+
+	var lines []string
+	for _, e := range entries {
+		lines = append(lines, fmt.Sprintf("%s  %s", e.hash, e.filename))
+	}
+
+	return strings.Join(lines, "\n") + "\n"
+}
+
+// generateTestPGPKey creates a new PGP entity for test signing. The key is
+// ephemeral and used only within the test run.
+func generateTestPGPKey(t *testing.T) *openpgp.Entity {
+	t.Helper()
+
+	entity, err := openpgp.NewEntity("tfenv-test", "test signing key", "test@tfenv.test", &packet.Config{
+		DefaultHash: crypto.SHA256,
+	})
+	if err != nil {
+		t.Fatalf("failed to generate test PGP key: %v", err)
+	}
+
+	return entity
+}
+
+// armorPublicKey exports the public key of an entity in ASCII-armored format.
+func armorPublicKey(t *testing.T, entity *openpgp.Entity) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	if err != nil {
+		t.Fatalf("failed to create armor encoder: %v", err)
+	}
+	if err := entity.Serialize(w); err != nil {
+		t.Fatalf("failed to serialize public key: %v", err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("failed to close armor encoder: %v", err)
+	}
+
+	return buf.String()
+}

--- a/go/test/acceptance/scaffolding_test.go
+++ b/go/test/acceptance/scaffolding_test.go
@@ -1,0 +1,209 @@
+package acceptance
+
+import (
+	"io"
+	"net/http"
+	"regexp"
+	"strings"
+	"testing"
+
+	"golang.org/x/crypto/openpgp"
+)
+
+// TestTfenvVersion validates that the binary under test prints a version
+// string and exits 0.
+func TestTfenvVersion(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runTfenv(t, "version")
+	assertExitCode(t, exitCode, 0)
+	assertOutputContains(t, stdout, "tfenv")
+}
+
+// TestTfenvHelp validates that the binary prints help text and exits 0.
+func TestTfenvHelp(t *testing.T) {
+	t.Parallel()
+
+	stdout, _, exitCode := runTfenv(t, "help")
+	assertExitCode(t, exitCode, 0)
+	assertOutputContains(t, stdout, "Usage:")
+}
+
+// TestTfenvUnknownCommand validates that the binary exits non-zero and
+// prints an error when given an unknown subcommand.
+func TestTfenvUnknownCommand(t *testing.T) {
+	t.Parallel()
+
+	_, stderr, exitCode := runTfenv(t, "not-a-command")
+
+	if exitCode == 0 {
+		t.Errorf("expected non-zero exit code for unknown command, got 0")
+	}
+	assertOutputContains(t, stderr, "unknown command")
+}
+
+// TestMockServerServesVersionIndex validates that the mock release server
+// returns an HTML page with version links that are parseable by the same
+// regex the Bash edition uses.
+func TestMockServerServesVersionIndex(t *testing.T) {
+	t.Parallel()
+
+	mock := startMockReleaseServer(t)
+
+	resp, err := http.Get(mock.URL + "/terraform/")
+	if err != nil {
+		t.Fatalf("failed to GET version index: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	html := string(body)
+
+	// The Bash edition uses this regex to extract versions.
+	re := regexp.MustCompile(`[0-9]+\.[0-9]+\.[0-9]+(-(rc|beta|alpha|oci)-?[0-9]*)?`)
+	matches := re.FindAllString(html, -1)
+
+	if len(matches) == 0 {
+		t.Fatalf("expected version matches in index page, got none.\nBody:\n%s", html)
+	}
+
+	// Check that our known versions appear.
+	found := make(map[string]bool)
+	for _, m := range matches {
+		found[m] = true
+	}
+
+	for _, want := range []string{"1.6.1", "1.6.0", "1.5.7", "1.5.7-rc1"} {
+		if !found[want] {
+			t.Errorf("expected version %q in index, found: %v", want, found)
+		}
+	}
+}
+
+// TestMockServerServesZip validates that a zip archive can be downloaded
+// for a known version and platform.
+func TestMockServerServesZip(t *testing.T) {
+	t.Parallel()
+
+	mock := startMockReleaseServer(t)
+
+	releases := defaultMockReleases()
+	r := releases[0] // 1.6.1
+	p := r.Platforms[0]
+
+	url := mock.URL + "/terraform/" + r.Version + "/terraform_" + r.Version + "_" + p.OS + "_" + p.Arch + ".zip"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("failed to GET zip: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read zip body: %v", err)
+	}
+
+	if len(body) == 0 {
+		t.Fatal("zip body is empty")
+	}
+
+	// Quick validation: zip files start with PK signature (0x504b).
+	if body[0] != 0x50 || body[1] != 0x4b {
+		t.Fatalf("downloaded content does not look like a zip (first bytes: %x %x)", body[0], body[1])
+	}
+}
+
+// TestMockServerServesSHA256SUMS validates that the SHA256SUMS file is
+// served correctly and contains expected hash/filename lines.
+func TestMockServerServesSHA256SUMS(t *testing.T) {
+	t.Parallel()
+
+	mock := startMockReleaseServer(t)
+
+	url := mock.URL + "/terraform/1.6.1/terraform_1.6.1_SHA256SUMS"
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("failed to GET SHA256SUMS: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read SHA256SUMS body: %v", err)
+	}
+
+	content := string(body)
+	if !strings.Contains(content, "terraform_1.6.1_") {
+		t.Errorf("SHA256SUMS does not reference expected filename.\nContent:\n%s", content)
+	}
+
+	// Each line should be: <hex hash>  <filename>
+	for _, line := range strings.Split(strings.TrimSpace(content), "\n") {
+		parts := strings.SplitN(line, "  ", 2)
+		if len(parts) != 2 {
+			t.Errorf("malformed SHA256SUMS line: %q", line)
+			continue
+		}
+		if len(parts[0]) != 64 {
+			t.Errorf("hash length is %d, want 64: %q", len(parts[0]), parts[0])
+		}
+	}
+}
+
+// TestMockServerServesValidSignature validates that the PGP signature
+// served by the mock server can be verified against its public key.
+func TestMockServerServesValidSignature(t *testing.T) {
+	t.Parallel()
+
+	mock := startMockReleaseServer(t)
+
+	// Fetch SHA256SUMS.
+	sumsResp, err := http.Get(mock.URL + "/terraform/1.6.1/terraform_1.6.1_SHA256SUMS")
+	if err != nil {
+		t.Fatalf("failed to GET SHA256SUMS: %v", err)
+	}
+	defer sumsResp.Body.Close()
+	sumsBody, err := io.ReadAll(sumsResp.Body)
+	if err != nil {
+		t.Fatalf("failed to read SHA256SUMS: %v", err)
+	}
+
+	// Fetch signature.
+	sigResp, err := http.Get(mock.URL + "/terraform/1.6.1/terraform_1.6.1_SHA256SUMS.72D7468F.sig")
+	if err != nil {
+		t.Fatalf("failed to GET signature: %v", err)
+	}
+	defer sigResp.Body.Close()
+	sigBody, err := io.ReadAll(sigResp.Body)
+	if err != nil {
+		t.Fatalf("failed to read signature: %v", err)
+	}
+
+	// Build a keyring from the mock server's entity.
+	keyring := openpgp.EntityList{mock.PGPEntity}
+
+	// Verify the detached signature.
+	signer, err := openpgp.CheckDetachedSignature(
+		keyring,
+		strings.NewReader(string(sumsBody)),
+		strings.NewReader(string(sigBody)),
+	)
+	if err != nil {
+		t.Fatalf("signature verification failed: %v", err)
+	}
+
+	if signer == nil {
+		t.Fatal("signer is nil — verification succeeded but no signer returned")
+	}
+}

--- a/go/test/testdata/mock-releases/README.md
+++ b/go/test/testdata/mock-releases/README.md
@@ -1,0 +1,8 @@
+# Mock Releases Test Data
+
+This directory holds static test data for mock release artifacts.
+
+Currently, all mock release artifacts (zip archives, SHA256SUMS files, PGP
+signatures) are generated at test time by `mock_server_test.go`. This
+directory is reserved for any static fixtures that may be needed in the
+future.


### PR DESCRIPTION
Implements #490 — Shared acceptance test framework with mock release server for parity testing.

## Changes
- Acceptance test framework in `go/test/acceptance/`
- `TFENV_TEST_BINARY` env var for binary selection (skips gracefully when unset)
- Mock release server (httptest) serving version index, zips, SHA256SUMS, PGP signatures
- Ephemeral test PGP keypair for signature verification testing
- Helper functions: runTfenv, runTfenvWithEnv, setupTempHome, assertions
- Initial validation tests: version, help, unknown command, mock server (4 tests)
- Integration test build tag placeholder
- `go vet ./...` passes
- `go test ./...` passes (acceptance tests skip when TFENV_TEST_BINARY unset)
- All 7 acceptance tests pass with Go edition binary

## Verification
```
$ go vet ./...          # clean
$ go test ./...         # passes (acceptance skipped)
$ TFENV_TEST_BINARY=$(pwd)/tfenv-go go test ./test/acceptance/... -v -count=1
--- PASS: TestTfenvHelp (0.01s)
--- PASS: TestTfenvVersion (0.01s)
--- PASS: TestTfenvUnknownCommand (0.02s)
--- PASS: TestMockServerServesSHA256SUMS (0.09s)
--- PASS: TestMockServerServesValidSignature (0.17s)
--- PASS: TestMockServerServesVersionIndex (0.19s)
--- PASS: TestMockServerServesZip (0.22s)
PASS
```

## Dependencies
- `golang.org/x/crypto v0.50.0` for PGP key generation and signing (requires go 1.25.0)

Closes #490