### PR TITLE
[STACKED] feat: configuration, state directory & platform detection

### DIFF
--- a/go/internal/config/config.go
+++ b/go/internal/config/config.go
@@ -1,2 +1,138 @@
 // Package config handles environment variable loading and state directory resolution.
 package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// Config aggregates all resolved configuration from TFENV_* environment variables.
+// Loaded once at startup and passed to commands.
+type Config struct {
+	ConfigDir          string // TFENV_CONFIG_DIR — state directory (default: ~/.tfenv/)
+	Root               string // TFENV_ROOT — Bash edition install dir (read-only, for compat)
+	Remote             string // TFENV_REMOTE — mirror URL (default: https://releases.hashicorp.com)
+	Arch               string // TFENV_ARCH — architecture override
+	AutoInstall        bool   // TFENV_AUTO_INSTALL — auto-install on exec (default: true)
+	CurlOutput         int    // TFENV_CURL_OUTPUT — download progress verbosity (0=quiet, 1=progress, 2=verbose)
+	TerraformVersion   string // TFENV_TERRAFORM_VERSION — version override (highest precedence)
+	NetrcPath          string // TFENV_NETRC_PATH — custom .netrc path
+	ReverseRemote      bool   // TFENV_REVERSE_REMOTE — reverse remote listing order
+	SortVersionsRemote bool   // TFENV_SORT_VERSIONS_REMOTE — sort remote by semver
+	SkipRemoteCheck    bool   // TFENV_SKIP_REMOTE_CHECK — skip remote during install
+	Dir                string // TFENV_DIR — override start dir for .terraform-version walk
+	PGPKeyPath         string // TFENV_PGP_KEY_PATH — custom PGP key for private mirrors
+	LogLevel           string // TFENV_LOG_LEVEL — logging level
+	LogFormat          string // TFENV_LOG_FORMAT — logging format (text/json)
+}
+
+// Load reads all TFENV_* environment variables, applies defaults, and returns
+// a fully resolved Config. It auto-creates ConfigDir and ConfigDir/versions/
+// if they don't exist. Returns an error only for genuinely invalid config
+// (e.g. unparseable int for TFENV_CURL_OUTPUT).
+func Load() (*Config, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving home directory: %w", err)
+	}
+
+	configDir := os.Getenv("TFENV_CONFIG_DIR")
+	if configDir == "" {
+		configDir = filepath.Join(homeDir, ".tfenv")
+	}
+
+	autoInstall, err := parseBool(os.Getenv("TFENV_AUTO_INSTALL"), true)
+	if err != nil {
+		return nil, fmt.Errorf("parsing TFENV_AUTO_INSTALL: %w", err)
+	}
+
+	curlOutput, err := parseInt(os.Getenv("TFENV_CURL_OUTPUT"), 0)
+	if err != nil {
+		return nil, fmt.Errorf("parsing TFENV_CURL_OUTPUT: %w", err)
+	}
+
+	remote := os.Getenv("TFENV_REMOTE")
+	if remote == "" {
+		remote = "https://releases.hashicorp.com"
+	}
+
+	reverseRemote, err := parseBool(os.Getenv("TFENV_REVERSE_REMOTE"), false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing TFENV_REVERSE_REMOTE: %w", err)
+	}
+
+	sortVersionsRemote, err := parseBool(os.Getenv("TFENV_SORT_VERSIONS_REMOTE"), false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing TFENV_SORT_VERSIONS_REMOTE: %w", err)
+	}
+
+	skipRemoteCheck, err := parseBool(os.Getenv("TFENV_SKIP_REMOTE_CHECK"), false)
+	if err != nil {
+		return nil, fmt.Errorf("parsing TFENV_SKIP_REMOTE_CHECK: %w", err)
+	}
+
+	cfg := &Config{
+		ConfigDir:          configDir,
+		Root:               os.Getenv("TFENV_ROOT"),
+		Remote:             remote,
+		Arch:               os.Getenv("TFENV_ARCH"),
+		AutoInstall:        autoInstall,
+		CurlOutput:         curlOutput,
+		TerraformVersion:   os.Getenv("TFENV_TERRAFORM_VERSION"),
+		NetrcPath:          os.Getenv("TFENV_NETRC_PATH"),
+		ReverseRemote:      reverseRemote,
+		SortVersionsRemote: sortVersionsRemote,
+		SkipRemoteCheck:    skipRemoteCheck,
+		Dir:                os.Getenv("TFENV_DIR"),
+		PGPKeyPath:         os.Getenv("TFENV_PGP_KEY_PATH"),
+		LogLevel:           os.Getenv("TFENV_LOG_LEVEL"),
+		LogFormat:          os.Getenv("TFENV_LOG_FORMAT"),
+	}
+
+	if err := ensureDir(cfg.ConfigDir); err != nil {
+		return nil, fmt.Errorf("creating config directory %q: %w", cfg.ConfigDir, err)
+	}
+
+	versionsDir := filepath.Join(cfg.ConfigDir, "versions")
+	if err := ensureDir(versionsDir); err != nil {
+		return nil, fmt.Errorf("creating versions directory %q: %w", versionsDir, err)
+	}
+
+	return cfg, nil
+}
+
+// parseBool parses a string as a boolean, accepting true/false/1/0 (case-insensitive).
+// Returns the defaultVal if the input is empty.
+func parseBool(s string, defaultVal bool) (bool, error) {
+	if s == "" {
+		return defaultVal, nil
+	}
+	switch strings.ToLower(s) {
+	case "true", "1":
+		return true, nil
+	case "false", "0":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean value: %q (expected true/false/1/0)", s)
+	}
+}
+
+// parseInt parses a string as an integer. Returns the defaultVal if the input is empty.
+func parseInt(s string, defaultVal int) (int, error) {
+	if s == "" {
+		return defaultVal, nil
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer value: %q", s)
+	}
+	return v, nil
+}
+
+// ensureDir creates a directory (and parents) if it doesn't already exist.
+func ensureDir(path string) error {
+	return os.MkdirAll(path, 0o755)
+}

--- a/go/internal/config/config_test.go
+++ b/go/internal/config/config_test.go
@@ -1,0 +1,364 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// clearEnv unsets all TFENV_* env vars to ensure a clean test environment.
+func clearEnv(t *testing.T) {
+	t.Helper()
+	vars := []string{
+		"TFENV_CONFIG_DIR",
+		"TFENV_ROOT",
+		"TFENV_REMOTE",
+		"TFENV_ARCH",
+		"TFENV_AUTO_INSTALL",
+		"TFENV_CURL_OUTPUT",
+		"TFENV_TERRAFORM_VERSION",
+		"TFENV_NETRC_PATH",
+		"TFENV_REVERSE_REMOTE",
+		"TFENV_SORT_VERSIONS_REMOTE",
+		"TFENV_SKIP_REMOTE_CHECK",
+		"TFENV_DIR",
+		"TFENV_PGP_KEY_PATH",
+		"TFENV_LOG_LEVEL",
+		"TFENV_LOG_FORMAT",
+	}
+	for _, v := range vars {
+		t.Setenv(v, "")
+		os.Unsetenv(v)
+	}
+}
+
+func TestLoad_Defaults(t *testing.T) {
+	clearEnv(t)
+
+	tmpDir := t.TempDir()
+	t.Setenv("TFENV_CONFIG_DIR", tmpDir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned unexpected error: %v", err)
+	}
+
+	if cfg.ConfigDir != tmpDir {
+		t.Errorf("ConfigDir = %q, want %q", cfg.ConfigDir, tmpDir)
+	}
+	if cfg.Remote != "https://releases.hashicorp.com" {
+		t.Errorf("Remote = %q, want %q", cfg.Remote, "https://releases.hashicorp.com")
+	}
+	if cfg.AutoInstall != true {
+		t.Errorf("AutoInstall = %v, want true", cfg.AutoInstall)
+	}
+	if cfg.CurlOutput != 0 {
+		t.Errorf("CurlOutput = %d, want 0", cfg.CurlOutput)
+	}
+	if cfg.Root != "" {
+		t.Errorf("Root = %q, want empty", cfg.Root)
+	}
+	if cfg.Arch != "" {
+		t.Errorf("Arch = %q, want empty", cfg.Arch)
+	}
+	if cfg.TerraformVersion != "" {
+		t.Errorf("TerraformVersion = %q, want empty", cfg.TerraformVersion)
+	}
+	if cfg.ReverseRemote != false {
+		t.Errorf("ReverseRemote = %v, want false", cfg.ReverseRemote)
+	}
+	if cfg.SortVersionsRemote != false {
+		t.Errorf("SortVersionsRemote = %v, want false", cfg.SortVersionsRemote)
+	}
+	if cfg.SkipRemoteCheck != false {
+		t.Errorf("SkipRemoteCheck = %v, want false", cfg.SkipRemoteCheck)
+	}
+}
+
+func TestLoad_DefaultConfigDir(t *testing.T) {
+	clearEnv(t)
+
+	// Use a temp dir as HOME to avoid polluting the real home directory.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned unexpected error: %v", err)
+	}
+
+	want := filepath.Join(tmpHome, ".tfenv")
+	if cfg.ConfigDir != want {
+		t.Errorf("ConfigDir = %q, want %q", cfg.ConfigDir, want)
+	}
+}
+
+func TestLoad_ConfigDirAutoCreated(t *testing.T) {
+	clearEnv(t)
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "newdir", ".tfenv")
+	t.Setenv("TFENV_CONFIG_DIR", configDir)
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned unexpected error: %v", err)
+	}
+
+	if cfg.ConfigDir != configDir {
+		t.Errorf("ConfigDir = %q, want %q", cfg.ConfigDir, configDir)
+	}
+
+	// Verify the directory was actually created.
+	info, err := os.Stat(configDir)
+	if err != nil {
+		t.Fatalf("ConfigDir not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("ConfigDir is not a directory")
+	}
+
+	// Verify versions/ subdirectory was created.
+	versionsDir := filepath.Join(configDir, "versions")
+	info, err = os.Stat(versionsDir)
+	if err != nil {
+		t.Fatalf("versions/ not created: %v", err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("versions/ is not a directory")
+	}
+}
+
+func TestLoad_StringEnvVars(t *testing.T) {
+	clearEnv(t)
+
+	tmpDir := t.TempDir()
+	t.Setenv("TFENV_CONFIG_DIR", tmpDir)
+	t.Setenv("TFENV_ROOT", "/opt/tfenv")
+	t.Setenv("TFENV_REMOTE", "https://my-mirror.example.com")
+	t.Setenv("TFENV_ARCH", "arm64")
+	t.Setenv("TFENV_TERRAFORM_VERSION", "1.5.0")
+	t.Setenv("TFENV_NETRC_PATH", "/home/user/.netrc")
+	t.Setenv("TFENV_DIR", "/workspace")
+	t.Setenv("TFENV_PGP_KEY_PATH", "/keys/custom.pgp")
+	t.Setenv("TFENV_LOG_LEVEL", "debug")
+	t.Setenv("TFENV_LOG_FORMAT", "json")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned unexpected error: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"Root", cfg.Root, "/opt/tfenv"},
+		{"Remote", cfg.Remote, "https://my-mirror.example.com"},
+		{"Arch", cfg.Arch, "arm64"},
+		{"TerraformVersion", cfg.TerraformVersion, "1.5.0"},
+		{"NetrcPath", cfg.NetrcPath, "/home/user/.netrc"},
+		{"Dir", cfg.Dir, "/workspace"},
+		{"PGPKeyPath", cfg.PGPKeyPath, "/keys/custom.pgp"},
+		{"LogLevel", cfg.LogLevel, "debug"},
+		{"LogFormat", cfg.LogFormat, "json"},
+	}
+
+	for _, tt := range tests {
+		if tt.got != tt.want {
+			t.Errorf("%s = %q, want %q", tt.name, tt.got, tt.want)
+		}
+	}
+}
+
+func TestLoad_AutoInstallParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVal  string
+		want    bool
+		wantErr bool
+	}{
+		{"empty defaults true", "", true, false},
+		{"true", "true", true, false},
+		{"TRUE", "TRUE", true, false},
+		{"1", "1", true, false},
+		{"false", "false", false, false},
+		{"FALSE", "FALSE", false, false},
+		{"0", "0", false, false},
+		{"invalid", "yes", false, true},
+		{"invalid number", "2", false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearEnv(t)
+
+			tmpDir := t.TempDir()
+			t.Setenv("TFENV_CONFIG_DIR", tmpDir)
+
+			if tt.envVal != "" {
+				t.Setenv("TFENV_AUTO_INSTALL", tt.envVal)
+			}
+
+			cfg, err := Load()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for TFENV_AUTO_INSTALL=%q, got nil", tt.envVal)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.AutoInstall != tt.want {
+				t.Errorf("AutoInstall = %v, want %v", cfg.AutoInstall, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoad_CurlOutputParsing(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVal  string
+		want    int
+		wantErr bool
+	}{
+		{"empty defaults 0", "", 0, false},
+		{"0", "0", 0, false},
+		{"1", "1", 1, false},
+		{"2", "2", 2, false},
+		{"invalid", "abc", 0, true},
+		{"float", "1.5", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clearEnv(t)
+
+			tmpDir := t.TempDir()
+			t.Setenv("TFENV_CONFIG_DIR", tmpDir)
+
+			if tt.envVal != "" {
+				t.Setenv("TFENV_CURL_OUTPUT", tt.envVal)
+			}
+
+			cfg, err := Load()
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for TFENV_CURL_OUTPUT=%q, got nil", tt.envVal)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if cfg.CurlOutput != tt.want {
+				t.Errorf("CurlOutput = %d, want %d", cfg.CurlOutput, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoad_BoolEnvVars(t *testing.T) {
+	clearEnv(t)
+
+	tmpDir := t.TempDir()
+	t.Setenv("TFENV_CONFIG_DIR", tmpDir)
+	t.Setenv("TFENV_REVERSE_REMOTE", "true")
+	t.Setenv("TFENV_SORT_VERSIONS_REMOTE", "1")
+	t.Setenv("TFENV_SKIP_REMOTE_CHECK", "TRUE")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() returned unexpected error: %v", err)
+	}
+
+	if cfg.ReverseRemote != true {
+		t.Errorf("ReverseRemote = %v, want true", cfg.ReverseRemote)
+	}
+	if cfg.SortVersionsRemote != true {
+		t.Errorf("SortVersionsRemote = %v, want true", cfg.SortVersionsRemote)
+	}
+	if cfg.SkipRemoteCheck != true {
+		t.Errorf("SkipRemoteCheck = %v, want true", cfg.SkipRemoteCheck)
+	}
+}
+
+func TestParseBool(t *testing.T) {
+	tests := []struct {
+		input      string
+		defaultVal bool
+		want       bool
+		wantErr    bool
+	}{
+		{"", true, true, false},
+		{"", false, false, false},
+		{"true", false, true, false},
+		{"True", false, true, false},
+		{"TRUE", false, true, false},
+		{"1", false, true, false},
+		{"false", true, false, false},
+		{"False", true, false, false},
+		{"FALSE", true, false, false},
+		{"0", true, false, false},
+		{"yes", false, false, true},
+		{"no", true, false, true},
+		{"2", false, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseBool(tt.input, tt.defaultVal)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseBool(%q, %v) = %v, want %v", tt.input, tt.defaultVal, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseInt(t *testing.T) {
+	tests := []struct {
+		input      string
+		defaultVal int
+		want       int
+		wantErr    bool
+	}{
+		{"", 0, 0, false},
+		{"", 5, 5, false},
+		{"0", 5, 0, false},
+		{"1", 0, 1, false},
+		{"42", 0, 42, false},
+		{"-1", 0, -1, false},
+		{"abc", 0, 0, true},
+		{"1.5", 0, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseInt(tt.input, tt.defaultVal)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil", tt.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tt.input, err)
+			}
+			if got != tt.want {
+				t.Errorf("parseInt(%q, %d) = %d, want %d", tt.input, tt.defaultVal, got, tt.want)
+			}
+		})
+	}
+}

--- a/go/internal/platform/platform.go
+++ b/go/internal/platform/platform.go
@@ -1,2 +1,180 @@
 // Package platform detects the current OS, architecture, and platform-specific behaviour.
 package platform
+
+import (
+	"fmt"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Platform represents the OS and architecture for Terraform binary downloads.
+type Platform struct {
+	OS   string // Terraform kernel string (darwin, linux, windows, freebsd)
+	Arch string // Terraform arch string, respects TFENV_ARCH override
+}
+
+// Detect returns the current platform, using runtime.GOOS and runtime.GOARCH
+// mapped to Terraform's naming conventions. If archOverride is non-empty, it
+// is used instead of the detected architecture.
+func Detect(archOverride string) Platform {
+	p := Platform{
+		OS:   mapOS(runtime.GOOS),
+		Arch: mapArch(runtime.GOARCH),
+	}
+	if archOverride != "" {
+		p.Arch = archOverride
+	}
+	return p
+}
+
+// String returns the platform in "os_arch" format (e.g. "linux_amd64").
+func (p Platform) String() string {
+	return fmt.Sprintf("%s_%s", p.OS, p.Arch)
+}
+
+// DownloadArch returns the architecture string to use for downloading a given
+// Terraform version. When the arch is arm64, certain old versions don't have
+// ARM64 binaries available, so this method falls back to amd64 for those.
+func (p Platform) DownloadArch(version string) string {
+	if p.Arch != "arm64" {
+		return p.Arch
+	}
+
+	switch p.OS {
+	case "linux":
+		if needsLinuxARM64Fallback(version) {
+			return "amd64"
+		}
+	case "darwin":
+		if needsDarwinARM64Fallback(version) {
+			return "amd64"
+		}
+	}
+
+	return p.Arch
+}
+
+// needsLinuxARM64Fallback returns true if the given version requires falling
+// back from arm64 to amd64 on Linux.
+//
+// Fallback ranges:
+//   - Versions < 0.11.15
+//   - Versions >= 0.12.0 and < 0.12.30
+//   - Versions >= 0.13.0 and < 0.13.5
+func needsLinuxARM64Fallback(version string) bool {
+	major, minor, patch, ok := parseVersion(version)
+	if !ok {
+		return false
+	}
+
+	v := semver{major, minor, patch}
+
+	// < 0.11.15
+	if v.less(semver{0, 11, 15}) {
+		return true
+	}
+
+	// >= 0.12.0 and < 0.12.30
+	if !v.less(semver{0, 12, 0}) && v.less(semver{0, 12, 30}) {
+		return true
+	}
+
+	// >= 0.13.0 and < 0.13.5
+	if !v.less(semver{0, 13, 0}) && v.less(semver{0, 13, 5}) {
+		return true
+	}
+
+	return false
+}
+
+// needsDarwinARM64Fallback returns true if the given version requires falling
+// back from arm64 to amd64 on macOS (Apple Silicon).
+//
+// Fallback range: versions < 1.0.2
+func needsDarwinARM64Fallback(version string) bool {
+	major, minor, patch, ok := parseVersion(version)
+	if !ok {
+		return false
+	}
+	return (semver{major, minor, patch}).less(semver{1, 0, 2})
+}
+
+// semver is a minimal semver triple for comparison purposes.
+type semver struct {
+	major, minor, patch int
+}
+
+// less returns true if s < other.
+func (s semver) less(other semver) bool {
+	if s.major != other.major {
+		return s.major < other.major
+	}
+	if s.minor != other.minor {
+		return s.minor < other.minor
+	}
+	return s.patch < other.patch
+}
+
+// parseVersion extracts major.minor.patch from a version string. It strips
+// any leading "v" and ignores pre-release suffixes (e.g. "-rc1").
+func parseVersion(version string) (major, minor, patch int, ok bool) {
+	version = strings.TrimPrefix(version, "v")
+
+	// Strip pre-release suffix (e.g. "-alpha1", "-rc1")
+	if idx := strings.IndexByte(version, '-'); idx >= 0 {
+		version = version[:idx]
+	}
+
+	parts := strings.Split(version, ".")
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	patch, err = strconv.Atoi(parts[2])
+	if err != nil {
+		return 0, 0, 0, false
+	}
+
+	return major, minor, patch, true
+}
+
+// mapOS maps runtime.GOOS to the Terraform download kernel string.
+func mapOS(goos string) string {
+	switch goos {
+	case "darwin":
+		return "darwin"
+	case "linux":
+		return "linux"
+	case "windows":
+		return "windows"
+	case "freebsd":
+		return "freebsd"
+	default:
+		return goos
+	}
+}
+
+// mapArch maps runtime.GOARCH to the Terraform download arch string.
+func mapArch(goarch string) string {
+	switch goarch {
+	case "amd64":
+		return "amd64"
+	case "arm64":
+		return "arm64"
+	case "386":
+		return "386"
+	case "arm":
+		return "arm"
+	default:
+		return goarch
+	}
+}

--- a/go/internal/platform/platform_test.go
+++ b/go/internal/platform/platform_test.go
@@ -1,0 +1,285 @@
+package platform
+
+import (
+	"testing"
+)
+
+func TestDetect_UsesOverride(t *testing.T) {
+	p := Detect("arm64")
+	if p.Arch != "arm64" {
+		t.Errorf("Detect(arm64).Arch = %q, want %q", p.Arch, "arm64")
+	}
+}
+
+func TestDetect_EmptyOverrideUsesRuntime(t *testing.T) {
+	p := Detect("")
+	if p.OS == "" {
+		t.Error("Detect(\"\").OS is empty, expected a value from runtime.GOOS")
+	}
+	if p.Arch == "" {
+		t.Error("Detect(\"\").Arch is empty, expected a value from runtime.GOARCH")
+	}
+}
+
+func TestPlatform_String(t *testing.T) {
+	tests := []struct {
+		os   string
+		arch string
+		want string
+	}{
+		{"linux", "amd64", "linux_amd64"},
+		{"darwin", "arm64", "darwin_arm64"},
+		{"windows", "386", "windows_386"},
+		{"freebsd", "arm", "freebsd_arm"},
+	}
+
+	for _, tt := range tests {
+		p := Platform{OS: tt.os, Arch: tt.arch}
+		got := p.String()
+		if got != tt.want {
+			t.Errorf("Platform{%q, %q}.String() = %q, want %q", tt.os, tt.arch, got, tt.want)
+		}
+	}
+}
+
+func TestMapOS(t *testing.T) {
+	tests := []struct {
+		goos string
+		want string
+	}{
+		{"darwin", "darwin"},
+		{"linux", "linux"},
+		{"windows", "windows"},
+		{"freebsd", "freebsd"},
+		{"openbsd", "openbsd"}, // unknown passes through
+	}
+
+	for _, tt := range tests {
+		got := mapOS(tt.goos)
+		if got != tt.want {
+			t.Errorf("mapOS(%q) = %q, want %q", tt.goos, got, tt.want)
+		}
+	}
+}
+
+func TestMapArch(t *testing.T) {
+	tests := []struct {
+		goarch string
+		want   string
+	}{
+		{"amd64", "amd64"},
+		{"arm64", "arm64"},
+		{"386", "386"},
+		{"arm", "arm"},
+		{"mips", "mips"}, // unknown passes through
+	}
+
+	for _, tt := range tests {
+		got := mapArch(tt.goarch)
+		if got != tt.want {
+			t.Errorf("mapArch(%q) = %q, want %q", tt.goarch, got, tt.want)
+		}
+	}
+}
+
+func TestDownloadArch_NonARM64Passthrough(t *testing.T) {
+	tests := []struct {
+		arch    string
+		version string
+	}{
+		{"amd64", "0.10.0"},
+		{"386", "0.12.0"},
+		{"arm", "1.0.0"},
+	}
+
+	for _, tt := range tests {
+		p := Platform{OS: "linux", Arch: tt.arch}
+		got := p.DownloadArch(tt.version)
+		if got != tt.arch {
+			t.Errorf("Platform{linux, %q}.DownloadArch(%q) = %q, want %q",
+				tt.arch, tt.version, got, tt.arch)
+		}
+	}
+}
+
+func TestDownloadArch_LinuxARM64Fallback(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+		desc    string
+	}{
+		// Versions < 0.11.15 → fallback to amd64
+		{"0.10.0", "amd64", "pre-0.11 falls back"},
+		{"0.11.0", "amd64", "0.11.0 falls back"},
+		{"0.11.14", "amd64", "0.11.14 falls back"},
+
+		// 0.11.15 is the boundary → arm64
+		{"0.11.15", "arm64", "0.11.15 uses arm64"},
+		{"0.11.16", "arm64", "0.11.16 uses arm64"},
+
+		// Versions >= 0.12.0 and < 0.12.30 → fallback to amd64
+		{"0.12.0", "amd64", "0.12.0 falls back"},
+		{"0.12.15", "amd64", "0.12.15 falls back"},
+		{"0.12.29", "amd64", "0.12.29 falls back"},
+
+		// 0.12.30 is the boundary → arm64
+		{"0.12.30", "arm64", "0.12.30 uses arm64"},
+		{"0.12.31", "arm64", "0.12.31 uses arm64"},
+
+		// Versions >= 0.13.0 and < 0.13.5 → fallback to amd64
+		{"0.13.0", "amd64", "0.13.0 falls back"},
+		{"0.13.4", "amd64", "0.13.4 falls back"},
+
+		// 0.13.5 is the boundary → arm64
+		{"0.13.5", "arm64", "0.13.5 uses arm64"},
+		{"0.13.6", "arm64", "0.13.6 uses arm64"},
+
+		// Modern versions → arm64
+		{"0.14.0", "arm64", "0.14.0 uses arm64"},
+		{"1.0.0", "arm64", "1.0.0 uses arm64"},
+		{"1.5.0", "arm64", "1.5.0 uses arm64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			p := Platform{OS: "linux", Arch: "arm64"}
+			got := p.DownloadArch(tt.version)
+			if got != tt.want {
+				t.Errorf("DownloadArch(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDownloadArch_DarwinARM64Fallback(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+		desc    string
+	}{
+		// Versions < 1.0.2 → fallback to amd64
+		{"0.10.0", "amd64", "0.10.0 falls back"},
+		{"0.14.11", "amd64", "0.14.11 falls back"},
+		{"1.0.0", "amd64", "1.0.0 falls back"},
+		{"1.0.1", "amd64", "1.0.1 falls back"},
+
+		// 1.0.2 is the boundary → arm64
+		{"1.0.2", "arm64", "1.0.2 uses arm64"},
+		{"1.0.3", "arm64", "1.0.3 uses arm64"},
+		{"1.5.0", "arm64", "1.5.0 uses arm64"},
+		{"2.0.0", "arm64", "2.0.0 uses arm64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			p := Platform{OS: "darwin", Arch: "arm64"}
+			got := p.DownloadArch(tt.version)
+			if got != tt.want {
+				t.Errorf("DownloadArch(%q) = %q, want %q", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDownloadArch_WindowsARM64NoFallback(t *testing.T) {
+	// Windows ARM64 has no special fallback logic.
+	p := Platform{OS: "windows", Arch: "arm64"}
+	got := p.DownloadArch("0.10.0")
+	if got != "arm64" {
+		t.Errorf("Windows ARM64 DownloadArch(0.10.0) = %q, want %q", got, "arm64")
+	}
+}
+
+func TestParseVersion(t *testing.T) {
+	tests := []struct {
+		input              string
+		wantMajor          int
+		wantMinor          int
+		wantPatch          int
+		wantOK             bool
+	}{
+		{"1.0.0", 1, 0, 0, true},
+		{"0.12.30", 0, 12, 30, true},
+		{"0.13.5", 0, 13, 5, true},
+		{"v1.5.3", 1, 5, 3, true},
+		{"1.0.0-rc1", 1, 0, 0, true},
+		{"1.0.0-alpha20210623", 1, 0, 0, true},
+		{"", 0, 0, 0, false},
+		{"1.0", 0, 0, 0, false},
+		{"abc", 0, 0, 0, false},
+		{"1.2.abc", 0, 0, 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			major, minor, patch, ok := parseVersion(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("parseVersion(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if !ok {
+				return
+			}
+			if major != tt.wantMajor || minor != tt.wantMinor || patch != tt.wantPatch {
+				t.Errorf("parseVersion(%q) = (%d, %d, %d), want (%d, %d, %d)",
+					tt.input, major, minor, patch, tt.wantMajor, tt.wantMinor, tt.wantPatch)
+			}
+		})
+	}
+}
+
+func TestSemver_Less(t *testing.T) {
+	tests := []struct {
+		a    semver
+		b    semver
+		want bool
+	}{
+		{semver{0, 0, 0}, semver{0, 0, 1}, true},
+		{semver{0, 0, 1}, semver{0, 0, 0}, false},
+		{semver{0, 0, 0}, semver{0, 0, 0}, false},
+		{semver{0, 1, 0}, semver{0, 2, 0}, true},
+		{semver{0, 2, 0}, semver{0, 1, 0}, false},
+		{semver{1, 0, 0}, semver{2, 0, 0}, true},
+		{semver{2, 0, 0}, semver{1, 0, 0}, false},
+		{semver{0, 11, 14}, semver{0, 11, 15}, true},
+		{semver{0, 11, 15}, semver{0, 11, 15}, false},
+		{semver{0, 12, 29}, semver{0, 12, 30}, true},
+		{semver{0, 13, 4}, semver{0, 13, 5}, true},
+		{semver{1, 0, 1}, semver{1, 0, 2}, true},
+	}
+
+	for _, tt := range tests {
+		got := tt.a.less(tt.b)
+		if got != tt.want {
+			t.Errorf("semver{%d,%d,%d}.less(semver{%d,%d,%d}) = %v, want %v",
+				tt.a.major, tt.a.minor, tt.a.patch,
+				tt.b.major, tt.b.minor, tt.b.patch,
+				got, tt.want)
+		}
+	}
+}
+
+func TestDownloadArch_InvalidVersion(t *testing.T) {
+	// Invalid versions should not cause fallback — return the arch as-is.
+	p := Platform{OS: "linux", Arch: "arm64"}
+	got := p.DownloadArch("invalid")
+	if got != "arm64" {
+		t.Errorf("DownloadArch(invalid) = %q, want %q", got, "arm64")
+	}
+}
+
+func TestDownloadArch_PreReleaseVersion(t *testing.T) {
+	// Pre-release versions should parse correctly.
+	p := Platform{OS: "darwin", Arch: "arm64"}
+
+	// 1.0.2-rc1 should be >= 1.0.2 base, so arm64
+	got := p.DownloadArch("1.0.2-rc1")
+	if got != "arm64" {
+		t.Errorf("DownloadArch(1.0.2-rc1) = %q, want %q", got, "arm64")
+	}
+
+	// 1.0.1-rc1 base is 1.0.1 which is < 1.0.2, so amd64
+	got = p.DownloadArch("1.0.1-rc1")
+	if got != "amd64" {
+		t.Errorf("DownloadArch(1.0.1-rc1) = %q, want %q", got, "amd64")
+	}
+}


### PR DESCRIPTION
Implements #492 — Configuration loading, state directory resolution, and platform detection for the Go edition.

## Changes
- `go/internal/config/` — full TFENV_* environment variable loading with defaults
- `go/internal/platform/` — OS/arch detection with ARM64 version cutoff fallbacks
- State directory auto-creation (~/.tfenv/versions/)
- Comprehensive table-driven unit tests for both packages

## Testing
- `go vet ./...` — passes
- `go test ./... -v` — all pass (60+ tests)
- `go test -race ./...` — no races

Closes #492