### PR TITLE
[STACKED] feat: version file resolution with .terraform-version walk

### DIFF
--- a/go/internal/resolve/resolve.go
+++ b/go/internal/resolve/resolve.go
@@ -1,2 +1,187 @@
-// Package resolve implements .terraform-version file discovery and version constraint resolution.
+// Package resolve implements .terraform-version file discovery and version
+// constraint resolution. It walks the directory tree upward to find version
+// files, parses their content, and applies the tfenv version precedence chain.
 package resolve
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/tfutils/tfenv/go/internal/config"
+	"github.com/tfutils/tfenv/go/internal/logging"
+)
+
+// VersionResult holds the resolved version string and the source that
+// provided it (for diagnostics and logging).
+type VersionResult struct {
+	Version string // The version string or keyword (e.g. "1.5.0", "latest", "latest:^1.5")
+	Source  string // Where it came from: "TFENV_TERRAFORM_VERSION", "/path/to/.terraform-version", etc.
+}
+
+// versionFileName is the name of the per-directory version file.
+const versionFileName = ".terraform-version"
+
+// ResolveVersionFile determines the Terraform version to use by searching
+// the following sources in order of decreasing precedence:
+//
+//  1. TFENV_TERRAFORM_VERSION environment variable (Config.TerraformVersion)
+//  2. .terraform-version in Config.Dir (or working directory)
+//  3. .terraform-version walking up parent directories toward filesystem root
+//  4. .terraform-version walking up from $HOME toward filesystem root
+//  5. ${Config.ConfigDir}/version (default version file)
+//
+// Returns an error if no version is found anywhere.
+func ResolveVersionFile(cfg *config.Config) (*VersionResult, error) {
+	// 1. Environment variable takes highest precedence.
+	if cfg.TerraformVersion != "" {
+		version := cleanVersion(cfg.TerraformVersion)
+		logging.Debug("version set by TFENV_TERRAFORM_VERSION", "version", version)
+		return &VersionResult{
+			Version: version,
+			Source:  "TFENV_TERRAFORM_VERSION",
+		}, nil
+	}
+
+	logging.Debug("TFENV_TERRAFORM_VERSION not set, searching for version file")
+
+	// 2–3. Walk up from TFENV_DIR (or working directory).
+	startDir := cfg.Dir
+	if startDir == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return nil, fmt.Errorf("determining working directory: %w", err)
+		}
+		startDir = wd
+	}
+
+	if result, err := findVersionFileWalk(startDir); err != nil {
+		return nil, err
+	} else if result != nil {
+		return result, nil
+	}
+
+	// 4. Walk up from $HOME.
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("resolving home directory: %w", err)
+	}
+
+	if result, err := findVersionFileWalk(homeDir); err != nil {
+		return nil, err
+	} else if result != nil {
+		return result, nil
+	}
+
+	// 5. Fall back to ConfigDir/version.
+	defaultFile := filepath.Join(cfg.ConfigDir, "version")
+	logging.Debug("no version file found in search paths, checking default", "path", defaultFile)
+
+	result, err := readVersionFile(defaultFile)
+	if err != nil {
+		return nil, fmt.Errorf("no version file found: searched from %s and %s, "+
+			"and no default version in %s", startDir, homeDir, defaultFile)
+	}
+
+	return result, nil
+}
+
+// findVersionFileWalk walks from dir upward through parent directories
+// looking for a .terraform-version file. Returns nil, nil if no file is
+// found (not an error — the caller should try the next search path).
+func findVersionFileWalk(dir string) (*VersionResult, error) {
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolving absolute path for %q: %w", dir, err)
+	}
+
+	logging.Debug("walking directory tree for version file", "start", dir)
+
+	for {
+		candidate := filepath.Join(dir, versionFileName)
+		logging.Debug("checking for version file", "path", candidate)
+
+		if _, err := os.Stat(candidate); err == nil {
+			result, err := readVersionFile(candidate)
+			if err != nil {
+				logging.Debug("version file found but unreadable or empty", "path", candidate, "err", err)
+			} else {
+				logging.Debug("version file found", "path", candidate, "version", result.Version)
+				return result, nil
+			}
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			// Reached filesystem root.
+			break
+		}
+		dir = parent
+	}
+
+	return nil, nil
+}
+
+// readVersionFile reads and parses a version file, returning the first
+// non-empty line after stripping comments, whitespace, carriage returns,
+// and a leading "v" prefix.
+func readVersionFile(path string) (*VersionResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading version file %q: %w", path, err)
+	}
+
+	version := parseVersionContent(string(data))
+	if version == "" {
+		return nil, fmt.Errorf("version file %q is empty or contains only comments", path)
+	}
+
+	return &VersionResult{
+		Version: version,
+		Source:  path,
+	}, nil
+}
+
+// parseVersionContent extracts the version string from file content.
+// For each line it:
+//  1. Strips everything after # (comment removal)
+//  2. Strips carriage returns
+//  3. Trims whitespace
+//  4. Skips blank lines
+//  5. Returns the first non-empty line with any leading "v" prefix removed
+func parseVersionContent(content string) string {
+	for _, line := range strings.Split(content, "\n") {
+		// Strip comments.
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			line = line[:idx]
+		}
+
+		// Strip carriage returns.
+		line = strings.ReplaceAll(line, "\r", "")
+
+		// Trim whitespace.
+		line = strings.TrimSpace(line)
+
+		// Skip blank lines.
+		if line == "" {
+			continue
+		}
+
+		// Strip leading "v" prefix.
+		line = strings.TrimPrefix(line, "v")
+
+		return line
+	}
+
+	return ""
+}
+
+// cleanVersion trims whitespace, strips carriage returns, and removes a
+// leading "v" prefix from an environment variable value.
+func cleanVersion(v string) string {
+	v = strings.ReplaceAll(v, "\r", "")
+	v = strings.TrimSpace(v)
+	v = strings.TrimPrefix(v, "v")
+	return v
+}

--- a/go/internal/resolve/resolve_test.go
+++ b/go/internal/resolve/resolve_test.go
@@ -1,0 +1,666 @@
+package resolve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tfutils/tfenv/go/internal/config"
+)
+
+// ---------------------------------------------------------------------------
+// parseVersionContent unit tests
+// ---------------------------------------------------------------------------
+
+func TestParseVersionContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{
+			name:    "simple version",
+			content: "1.5.0\n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "latest keyword",
+			content: "latest\n",
+			want:    "latest",
+		},
+		{
+			name:    "latest with regex",
+			content: "latest:^1.5\n",
+			want:    "latest:^1.5",
+		},
+		{
+			name:    "v prefix stripped",
+			content: "v1.5.0\n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "comment stripped",
+			content: "1.5.0 # pinned for CI\n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "full line comment skipped",
+			content: "# this is a comment\n1.5.0\n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "carriage return stripped",
+			content: "1.5.0\r\n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "windows line endings",
+			content: "# comment\r\n1.5.0\r\n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "leading and trailing whitespace",
+			content: "  1.5.0  \n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "blank lines skipped",
+			content: "\n\n1.5.0\n\n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "empty content",
+			content: "",
+			want:    "",
+		},
+		{
+			name:    "only comments",
+			content: "# comment\n# another\n",
+			want:    "",
+		},
+		{
+			name:    "only whitespace",
+			content: "   \n  \n",
+			want:    "",
+		},
+		{
+			name:    "v prefix with leading space",
+			content: "  v1.5.0\n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "min-required keyword",
+			content: "min-required\n",
+			want:    "min-required",
+		},
+		{
+			name:    "latest-allowed keyword",
+			content: "latest-allowed\n",
+			want:    "latest-allowed",
+		},
+		{
+			name:    "inline comment with tabs",
+			content: "1.5.0\t# pinned\n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "multiple versions returns first",
+			content: "1.5.0\n1.6.0\n",
+			want:    "1.5.0",
+		},
+		{
+			name:    "carriage return only line",
+			content: "\r\n1.5.0\n",
+			want:    "1.5.0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseVersionContent(tc.content)
+			if got != tc.want {
+				t.Errorf("parseVersionContent(%q) = %q, want %q", tc.content, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cleanVersion unit tests
+// ---------------------------------------------------------------------------
+
+func TestCleanVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"1.5.0", "1.5.0"},
+		{"v1.5.0", "1.5.0"},
+		{" 1.5.0 ", "1.5.0"},
+		{"1.5.0\r", "1.5.0"},
+		{"v1.5.0\r\n", "1.5.0"},
+		{"latest", "latest"},
+		{"latest:^1.5", "latest:^1.5"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			got := cleanVersion(tc.input)
+			if got != tc.want {
+				t.Errorf("cleanVersion(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveVersionFile integration tests
+// ---------------------------------------------------------------------------
+
+// writeFile is a test helper that writes content to a file, creating
+// parent directories as needed.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("creating directory for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+func TestResolveVersionFile_EnvVarHighestPrecedence(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Place a version file that should be ignored.
+	writeFile(t, filepath.Join(startDir, versionFileName), "1.0.0\n")
+
+	cfg := &config.Config{
+		TerraformVersion: "1.9.0",
+		ConfigDir:        configDir,
+		Dir:              startDir,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.9.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.9.0")
+	}
+	if result.Source != "TFENV_TERRAFORM_VERSION" {
+		t.Errorf("Source = %q, want %q", result.Source, "TFENV_TERRAFORM_VERSION")
+	}
+}
+
+func TestResolveVersionFile_EnvVarVPrefixStripped(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{
+		TerraformVersion: "v1.9.0",
+		ConfigDir:        filepath.Join(tmp, "config"),
+		Dir:              tmp,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.9.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.9.0")
+	}
+}
+
+func TestResolveVersionFile_CurrentDir(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(startDir, versionFileName), "1.5.0\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       startDir,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.5.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.5.0")
+	}
+	if result.Source != filepath.Join(startDir, versionFileName) {
+		t.Errorf("Source = %q, want %q", result.Source, filepath.Join(startDir, versionFileName))
+	}
+}
+
+func TestResolveVersionFile_ParentDir(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	parent := filepath.Join(tmp, "project")
+	child := filepath.Join(parent, "modules", "vpc")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(parent, versionFileName), "1.4.0\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       child,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.4.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.4.0")
+	}
+	if result.Source != filepath.Join(parent, versionFileName) {
+		t.Errorf("Source = %q, want %q", result.Source, filepath.Join(parent, versionFileName))
+	}
+}
+
+func TestResolveVersionFile_GrandparentDir(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	grandchild := filepath.Join(tmp, "a", "b", "c")
+	if err := os.MkdirAll(grandchild, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(tmp, versionFileName), "1.3.0\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       grandchild,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.3.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.3.0")
+	}
+}
+
+func TestResolveVersionFile_ConfigDirFallback(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(configDir, "version"), "1.2.0\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       startDir,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.2.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.2.0")
+	}
+	if result.Source != filepath.Join(configDir, "version") {
+		t.Errorf("Source = %q, want %q", result.Source, filepath.Join(configDir, "version"))
+	}
+}
+
+func TestResolveVersionFile_NoVersionFound(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       startDir,
+	}
+
+	_, err := ResolveVersionFile(cfg)
+	if err == nil {
+		t.Fatal("expected error when no version file found, got nil")
+	}
+}
+
+func TestResolveVersionFile_EmptyFileReturnsError(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write an empty version file — should be skipped, not returned.
+	writeFile(t, filepath.Join(startDir, versionFileName), "")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       startDir,
+	}
+
+	_, err := ResolveVersionFile(cfg)
+	if err == nil {
+		t.Fatal("expected error for empty version file, got nil")
+	}
+}
+
+func TestResolveVersionFile_CommentOnlyFileSkipped(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	parent := filepath.Join(tmp)
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Comment-only file in startDir — should be skipped.
+	writeFile(t, filepath.Join(startDir, versionFileName), "# just a comment\n")
+	// Real version in parent.
+	writeFile(t, filepath.Join(parent, versionFileName), "1.6.0\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       startDir,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.6.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.6.0")
+	}
+}
+
+func TestResolveVersionFile_CarriageReturnsStripped(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(startDir, versionFileName), "1.5.0\r\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       startDir,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.5.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.5.0")
+	}
+}
+
+func TestResolveVersionFile_VPrefixInFile(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(startDir, versionFileName), "v1.5.0\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       startDir,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.5.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.5.0")
+	}
+}
+
+func TestResolveVersionFile_CommentsStrippedInFile(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(startDir, versionFileName), "# this project\n1.5.0 # pinned\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       startDir,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.5.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.5.0")
+	}
+}
+
+func TestResolveVersionFile_WindowsLineEndings(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(startDir, versionFileName), "# comment\r\n1.5.0\r\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       startDir,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.5.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.5.0")
+	}
+}
+
+func TestResolveVersionFile_TFENVDirOverride(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+
+	// Two different directories with different versions.
+	dirA := filepath.Join(tmp, "dirA")
+	dirB := filepath.Join(tmp, "dirB")
+	if err := os.MkdirAll(dirA, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(dirB, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(dirA, versionFileName), "1.1.0\n")
+	writeFile(t, filepath.Join(dirB, versionFileName), "1.2.0\n")
+
+	// Config.Dir is set to dirB — should use dirB's version.
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       dirB,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.2.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.2.0")
+	}
+}
+
+func TestResolveVersionFile_LatestKeyword(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(startDir, versionFileName), "latest:^1.5\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       startDir,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "latest:^1.5" {
+		t.Errorf("Version = %q, want %q", result.Version, "latest:^1.5")
+	}
+}
+
+func TestResolveVersionFile_PrecedenceLocalOverParent(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	parent := filepath.Join(tmp, "project")
+	child := filepath.Join(parent, "sub")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(parent, versionFileName), "1.0.0\n")
+	writeFile(t, filepath.Join(child, versionFileName), "1.1.0\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       child,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.1.0" {
+		t.Errorf("Version = %q, want %q (local should override parent)", result.Version, "1.1.0")
+	}
+}
+
+func TestResolveVersionFile_PrecedenceEnvOverLocal(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	startDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(startDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeFile(t, filepath.Join(startDir, versionFileName), "1.0.0\n")
+
+	cfg := &config.Config{
+		TerraformVersion: "1.9.0",
+		ConfigDir:        configDir,
+		Dir:              startDir,
+	}
+
+	result, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.9.0" {
+		t.Errorf("Version = %q, want %q (env should override local file)", result.Version, "1.9.0")
+	}
+	if result.Source != "TFENV_TERRAFORM_VERSION" {
+		t.Errorf("Source = %q, want TFENV_TERRAFORM_VERSION", result.Source)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// findVersionFileWalk unit tests
+// ---------------------------------------------------------------------------
+
+func TestFindVersionFileWalk_StopsAtRoot(t *testing.T) {
+	// Walk from a temp dir with no version file — should return nil, nil.
+	tmp := t.TempDir()
+	deep := filepath.Join(tmp, "a", "b", "c")
+	if err := os.MkdirAll(deep, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := findVersionFileWalk(deep)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result when no version file exists, got %+v", result)
+	}
+}
+
+func TestFindVersionFileWalk_FindsFileInStartDir(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, versionFileName), "1.5.0\n")
+
+	result, err := findVersionFileWalk(tmp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if result.Version != "1.5.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.5.0")
+	}
+}
+
+func TestFindVersionFileWalk_SkipsEmptyFile(t *testing.T) {
+	tmp := t.TempDir()
+	child := filepath.Join(tmp, "sub")
+	if err := os.MkdirAll(child, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Empty file in child — should be skipped, find parent's.
+	writeFile(t, filepath.Join(child, versionFileName), "")
+	writeFile(t, filepath.Join(tmp, versionFileName), "1.4.0\n")
+
+	result, err := findVersionFileWalk(child)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected result, got nil")
+	}
+	if result.Version != "1.4.0" {
+		t.Errorf("Version = %q, want %q", result.Version, "1.4.0")
+	}
+}


### PR DESCRIPTION
Implements #493 — .terraform-version file discovery and version precedence resolution.

## Changes
- Version file resolution in `go/internal/resolve/`
- Full precedence chain: env var > local file > directory walk > config default
- File content parsing: comments, whitespace, carriage returns, v-prefix
- Two-phase directory walk (from TFENV_DIR/PWD, then from HOME)
- Comprehensive table-driven unit tests (30 test cases)

## Acceptance Criteria Status
- [x] `TFENV_TERRAFORM_VERSION` takes highest precedence
- [x] `.terraform-version` in current dir found
- [x] Walk discovers file in parent directory
- [x] Walk discovers file in grandparent directory
- [x] Walk stops at filesystem root without error
- [x] `ConfigDir/version` fallback works
- [x] No version found returns clear error
- [x] Carriage returns stripped
- [x] Leading/trailing whitespace stripped
- [x] v-prefix stripped
- [x] Comments stripped
- [x] Empty file returns error
- [x] Windows-style line endings (\r\n)
- [x] TFENV_DIR overrides walk start
- [x] `go vet ./...` clean
- [x] `go test ./... -v` all pass
- [x] `go test -race ./...` clean

Closes #493