### PR TITLE
[STACKED] feat: remote and local version listing

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -5,8 +5,10 @@ go 1.25.0
 require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/log v1.0.0
+	github.com/hashicorp/go-version v1.9.0
 	github.com/muesli/termenv v0.16.0
 	golang.org/x/crypto v0.50.0
+	golang.org/x/net v0.53.0
 )
 
 require (

--- a/go/go.sum
+++ b/go/go.sum
@@ -18,6 +18,8 @@ github.com/go-logfmt/logfmt v0.6.1 h1:4hvbpePJKnIzH1B+8OR/JPbTx37NktoI9LE2QZBBkv
 github.com/go-logfmt/logfmt v0.6.1/go.mod h1:EV2pOAQoZaT1ZXZbqDl5hrymndi4SY9ED9/z6CO0XAk=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/hashicorp/go-version v1.9.0 h1:CeOIz6k+LoN3qX9Z0tyQrPtiB1DFYRPfCIBtaXPSCnA=
+github.com/hashicorp/go-version v1.9.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
@@ -39,6 +41,8 @@ golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
 golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
 golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/net v0.53.0 h1:d+qAbo5L0orcWAr0a9JweQpjXF19LMXJE8Ey7hwOdUA=
+golang.org/x/net v0.53.0/go.mod h1:JvMuJH7rrdiCfbeHoo3fCQU24Lf5JJwT9W3sJFulfgs=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.43.0 h1:Rlag2XtaFTxp19wS8MXlJwTvoh8ArU6ezoyFsMyCTNI=
 golang.org/x/sys v0.43.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/go/internal/list/list.go
+++ b/go/internal/list/list.go
@@ -1,2 +1,171 @@
 // Package list provides local and remote Terraform version listing.
 package list
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	goversion "github.com/hashicorp/go-version"
+	"golang.org/x/net/html"
+
+	"github.com/tfutils/tfenv/go/internal/config"
+	"github.com/tfutils/tfenv/go/internal/logging"
+)
+
+const (
+	httpTimeout = 30 * time.Second
+	userAgent   = "tfenv/go"
+)
+
+// ListRemote fetches available Terraform versions from the configured remote.
+// Returns versions sorted by semver (newest first by default).
+// cfg.ReverseRemote=true returns oldest first.
+func ListRemote(cfg *config.Config) ([]string, error) {
+	url := strings.TrimSuffix(cfg.Remote, "/") + "/terraform/"
+	logging.Debug("fetching remote version index", "url", url)
+
+	client := &http.Client{Timeout: httpTimeout}
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("building request for %s: %w", url, err)
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetching remote index from %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("remote index returned HTTP %d from %s", resp.StatusCode, url)
+	}
+
+	versions, err := parseVersionIndex(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("parsing remote version index: %w", err)
+	}
+
+	sortVersions(versions, cfg.ReverseRemote)
+	logging.Debug("fetched remote versions", "count", len(versions))
+	return versions, nil
+}
+
+// ListLocal returns locally installed versions from ConfigDir/versions/.
+// Each subdirectory name is an installed version. Returns versions sorted
+// by semver (newest first by default). cfg.ReverseRemote=true returns oldest first.
+func ListLocal(cfg *config.Config) ([]string, error) {
+	versionsDir := filepath.Join(cfg.ConfigDir, "versions")
+	logging.Debug("listing local versions", "dir", versionsDir)
+
+	entries, err := os.ReadDir(versionsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading versions directory %s: %w", versionsDir, err)
+	}
+
+	var versions []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if _, err := goversion.NewVersion(name); err == nil {
+			versions = append(versions, name)
+		}
+	}
+
+	sortVersions(versions, cfg.ReverseRemote)
+	logging.Debug("found local versions", "count", len(versions))
+	return versions, nil
+}
+
+// parseVersionIndex extracts version strings from HTML containing links in
+// the format <a href="/terraform/X.Y.Z/">. Uses golang.org/x/net/html for
+// proper HTML parsing.
+func parseVersionIndex(r io.Reader) ([]string, error) {
+	tokenizer := html.NewTokenizer(r)
+	var versions []string
+
+	for {
+		tt := tokenizer.Next()
+		switch tt {
+		case html.ErrorToken:
+			err := tokenizer.Err()
+			if err == io.EOF {
+				return versions, nil
+			}
+			return nil, fmt.Errorf("tokenizing HTML: %w", err)
+
+		case html.StartTagToken:
+			tn, hasAttr := tokenizer.TagName()
+			if string(tn) != "a" || !hasAttr {
+				continue
+			}
+			version := extractVersionFromAttrs(tokenizer)
+			if version != "" {
+				versions = append(versions, version)
+			}
+		}
+	}
+}
+
+// extractVersionFromAttrs scans the attributes of an <a> tag for an href
+// matching /terraform/VERSION/ and returns the VERSION string. Returns ""
+// if no matching href is found.
+func extractVersionFromAttrs(tokenizer *html.Tokenizer) string {
+	for {
+		key, val, more := tokenizer.TagAttr()
+		if string(key) == "href" {
+			if v := versionFromHref(string(val)); v != "" {
+				return v
+			}
+		}
+		if !more {
+			return ""
+		}
+	}
+}
+
+// versionFromHref extracts a version string from an href like
+// "/terraform/1.5.0/" or "terraform/1.5.0-rc1/". Returns "" if the
+// href does not match the expected pattern.
+func versionFromHref(href string) string {
+	// Strip leading slash and split.
+	href = strings.TrimPrefix(href, "/")
+	href = strings.TrimSuffix(href, "/")
+	parts := strings.Split(href, "/")
+
+	if len(parts) != 2 || parts[0] != "terraform" {
+		return ""
+	}
+
+	candidate := parts[1]
+	// Validate it parses as a semver version.
+	if _, err := goversion.NewVersion(candidate); err != nil {
+		return ""
+	}
+	return candidate
+}
+
+// sortVersions sorts a slice of version strings by semver. If reverse is
+// false, sorts newest first (descending). If reverse is true, sorts oldest
+// first (ascending).
+func sortVersions(versions []string, reverse bool) {
+	sort.Slice(versions, func(i, j int) bool {
+		vi, _ := goversion.NewVersion(versions[i])
+		vj, _ := goversion.NewVersion(versions[j])
+		if reverse {
+			return vi.LessThan(vj)
+		}
+		return vj.LessThan(vi)
+	})
+}

--- a/go/internal/list/list_test.go
+++ b/go/internal/list/list_test.go
@@ -1,0 +1,452 @@
+package list
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/tfutils/tfenv/go/internal/config"
+)
+
+// realisticHTML mirrors the format served by releases.hashicorp.com/terraform/.
+const realisticHTML = `<!DOCTYPE html>
+<html>
+<head><title>Terraform Versions</title></head>
+<body>
+<ul>
+  <li><a href="/terraform/1.10.0-alpha20240710/">terraform_1.10.0-alpha20240710</a></li>
+  <li><a href="/terraform/1.9.2/">terraform_1.9.2</a></li>
+  <li><a href="/terraform/1.9.1/">terraform_1.9.1</a></li>
+  <li><a href="/terraform/1.9.0/">terraform_1.9.0</a></li>
+  <li><a href="/terraform/1.9.0-rc2/">terraform_1.9.0-rc2</a></li>
+  <li><a href="/terraform/1.9.0-rc1/">terraform_1.9.0-rc1</a></li>
+  <li><a href="/terraform/1.9.0-beta1/">terraform_1.9.0-beta1</a></li>
+  <li><a href="/terraform/1.8.5/">terraform_1.8.5</a></li>
+  <li><a href="/terraform/1.8.4/">terraform_1.8.4</a></li>
+  <li><a href="/terraform/1.7.0/">terraform_1.7.0</a></li>
+  <li><a href="/terraform/0.14.11/">terraform_0.14.11</a></li>
+  <li><a href="/terraform/0.13.7/">terraform_0.13.7</a></li>
+</ul>
+</body>
+</html>`
+
+func TestParseVersionIndex(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		html    string
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "realistic hashicorp HTML",
+			html: realisticHTML,
+			want: []string{
+				"1.10.0-alpha20240710",
+				"1.9.2", "1.9.1", "1.9.0",
+				"1.9.0-rc2", "1.9.0-rc1", "1.9.0-beta1",
+				"1.8.5", "1.8.4",
+				"1.7.0",
+				"0.14.11", "0.13.7",
+			},
+		},
+		{
+			name: "empty page",
+			html: `<html><body></body></html>`,
+			want: nil,
+		},
+		{
+			name: "no terraform links",
+			html: `<html><body><a href="/packer/1.0.0/">packer_1.0.0</a></body></html>`,
+			want: nil,
+		},
+		{
+			name: "links without trailing slash",
+			html: `<html><body><a href="/terraform/1.5.0">terraform_1.5.0</a></body></html>`,
+			want: []string{"1.5.0"},
+		},
+		{
+			name: "mixed valid and invalid hrefs",
+			html: `<html><body>
+				<a href="/terraform/1.5.0/">terraform_1.5.0</a>
+				<a href="/terraform/notaversion/">terraform_notaversion</a>
+				<a href="/terraform/1.4.0/">terraform_1.4.0</a>
+			</body></html>`,
+			want: []string{"1.5.0", "1.4.0"},
+		},
+		{
+			name: "pre-release versions included",
+			html: `<html><body>
+				<a href="/terraform/1.6.0-alpha1/">terraform_1.6.0-alpha1</a>
+				<a href="/terraform/1.5.0-rc1/">terraform_1.5.0-rc1</a>
+				<a href="/terraform/1.5.0-beta2/">terraform_1.5.0-beta2</a>
+				<a href="/terraform/1.4.0/">terraform_1.4.0</a>
+			</body></html>`,
+			want: []string{"1.6.0-alpha1", "1.5.0-rc1", "1.5.0-beta2", "1.4.0"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := parseVersionIndex(strings.NewReader(tc.html))
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("parseVersionIndex() error = %v, wantErr = %v", err, tc.wantErr)
+			}
+			if !slicesEqual(got, tc.want) {
+				t.Errorf("parseVersionIndex() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSortVersions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   []string
+		reverse bool
+		want    []string
+	}{
+		{
+			name:    "descending (default)",
+			input:   []string{"1.0.0", "1.2.0", "0.14.11", "1.1.0"},
+			reverse: false,
+			want:    []string{"1.2.0", "1.1.0", "1.0.0", "0.14.11"},
+		},
+		{
+			name:    "ascending (reverse)",
+			input:   []string{"1.0.0", "1.2.0", "0.14.11", "1.1.0"},
+			reverse: true,
+			want:    []string{"0.14.11", "1.0.0", "1.1.0", "1.2.0"},
+		},
+		{
+			name:    "pre-releases sort before stable",
+			input:   []string{"1.5.0", "1.5.0-rc1", "1.5.0-beta1", "1.4.0"},
+			reverse: false,
+			want:    []string{"1.5.0", "1.5.0-rc1", "1.5.0-beta1", "1.4.0"},
+		},
+		{
+			name:    "pre-releases ascending",
+			input:   []string{"1.5.0", "1.5.0-rc1", "1.5.0-beta1", "1.4.0"},
+			reverse: true,
+			want:    []string{"1.4.0", "1.5.0-beta1", "1.5.0-rc1", "1.5.0"},
+		},
+		{
+			name:    "empty slice",
+			input:   []string{},
+			reverse: false,
+			want:    []string{},
+		},
+		{
+			name:    "single version",
+			input:   []string{"1.0.0"},
+			reverse: false,
+			want:    []string{"1.0.0"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := make([]string, len(tc.input))
+			copy(got, tc.input)
+			sortVersions(got, tc.reverse)
+			if !slicesEqual(got, tc.want) {
+				t.Errorf("sortVersions() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestListRemote(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		handler    http.HandlerFunc
+		reverse    bool
+		wantCount  int
+		wantFirst  string
+		wantLast   string
+		wantErr    bool
+		wantErrMsg string
+	}{
+		{
+			name: "successful fetch sorted descending",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				if r.Header.Get("User-Agent") != userAgent {
+					t.Errorf("expected User-Agent %q, got %q", userAgent, r.Header.Get("User-Agent"))
+				}
+				w.Header().Set("Content-Type", "text/html")
+				w.Write([]byte(realisticHTML))
+			},
+			reverse:   false,
+			wantCount: 12,
+			wantFirst: "1.10.0-alpha20240710",
+			wantLast:  "0.13.7",
+		},
+		{
+			name: "successful fetch sorted ascending",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				w.Write([]byte(realisticHTML))
+			},
+			reverse:   true,
+			wantCount: 12,
+			wantFirst: "0.13.7",
+			wantLast:  "1.10.0-alpha20240710",
+		},
+		{
+			name: "empty response",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "text/html")
+				w.Write([]byte(`<html><body></body></html>`))
+			},
+			wantCount: 0,
+		},
+		{
+			name: "HTTP 404",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+			wantErr:    true,
+			wantErrMsg: "HTTP 404",
+		},
+		{
+			name: "HTTP 500",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			wantErr:    true,
+			wantErrMsg: "HTTP 500",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(tc.handler)
+			t.Cleanup(server.Close)
+
+			cfg := &config.Config{
+				Remote:        server.URL,
+				ReverseRemote: tc.reverse,
+			}
+
+			got, err := ListRemote(cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.wantErrMsg != "" && !strings.Contains(err.Error(), tc.wantErrMsg) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.wantErrMsg)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(got) != tc.wantCount {
+				t.Errorf("got %d versions, want %d", len(got), tc.wantCount)
+			}
+			if tc.wantFirst != "" && len(got) > 0 && got[0] != tc.wantFirst {
+				t.Errorf("first version = %q, want %q", got[0], tc.wantFirst)
+			}
+			if tc.wantLast != "" && len(got) > 0 && got[len(got)-1] != tc.wantLast {
+				t.Errorf("last version = %q, want %q", got[len(got)-1], tc.wantLast)
+			}
+		})
+	}
+}
+
+func TestListLocal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(t *testing.T) string // returns configDir
+		reverse bool
+		want    []string
+		wantErr bool
+	}{
+		{
+			name: "multiple versions sorted descending",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				versionsDir := filepath.Join(dir, "versions")
+				for _, v := range []string{"1.0.0", "1.2.0", "0.14.11", "1.1.0"} {
+					if err := os.MkdirAll(filepath.Join(versionsDir, v), 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return dir
+			},
+			want: []string{"1.2.0", "1.1.0", "1.0.0", "0.14.11"},
+		},
+		{
+			name: "multiple versions sorted ascending",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				versionsDir := filepath.Join(dir, "versions")
+				for _, v := range []string{"1.0.0", "1.2.0", "0.14.11"} {
+					if err := os.MkdirAll(filepath.Join(versionsDir, v), 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return dir
+			},
+			reverse: true,
+			want:    []string{"0.14.11", "1.0.0", "1.2.0"},
+		},
+		{
+			name: "empty versions directory",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				if err := os.MkdirAll(filepath.Join(dir, "versions"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: nil,
+		},
+		{
+			name: "nonexistent versions directory",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				return t.TempDir()
+			},
+			want: nil,
+		},
+		{
+			name: "ignores non-directory entries",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				versionsDir := filepath.Join(dir, "versions")
+				if err := os.MkdirAll(filepath.Join(versionsDir, "1.5.0"), 0o755); err != nil {
+					t.Fatal(err)
+				}
+				// Create a regular file that looks like a version.
+				if err := os.WriteFile(filepath.Join(versionsDir, "1.4.0"), []byte("not a dir"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return dir
+			},
+			want: []string{"1.5.0"},
+		},
+		{
+			name: "ignores non-version directory names",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				versionsDir := filepath.Join(dir, "versions")
+				for _, v := range []string{"1.5.0", "notaversion", ".hidden"} {
+					if err := os.MkdirAll(filepath.Join(versionsDir, v), 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return dir
+			},
+			want: []string{"1.5.0"},
+		},
+		{
+			name: "pre-release versions included",
+			setup: func(t *testing.T) string {
+				t.Helper()
+				dir := t.TempDir()
+				versionsDir := filepath.Join(dir, "versions")
+				for _, v := range []string{"1.5.0", "1.5.0-rc1", "1.4.0"} {
+					if err := os.MkdirAll(filepath.Join(versionsDir, v), 0o755); err != nil {
+						t.Fatal(err)
+					}
+				}
+				return dir
+			},
+			want: []string{"1.5.0", "1.5.0-rc1", "1.4.0"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			configDir := tc.setup(t)
+			cfg := &config.Config{
+				ConfigDir:     configDir,
+				ReverseRemote: tc.reverse,
+			}
+
+			got, err := ListLocal(cfg)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if !slicesEqual(got, tc.want) {
+				t.Errorf("ListLocal() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVersionFromHref(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		href string
+		want string
+	}{
+		{"/terraform/1.5.0/", "1.5.0"},
+		{"/terraform/1.5.0-rc1/", "1.5.0-rc1"},
+		{"/terraform/0.14.11/", "0.14.11"},
+		{"terraform/1.5.0/", "1.5.0"},
+		{"/terraform/1.5.0", "1.5.0"},
+		{"/packer/1.5.0/", ""},
+		{"/terraform/", ""},
+		{"/terraform/notaversion/", ""},
+		{"", ""},
+		{"/", ""},
+		{"/terraform/1.5.0/extra/", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.href, func(t *testing.T) {
+			t.Parallel()
+			got := versionFromHref(tc.href)
+			if got != tc.want {
+				t.Errorf("versionFromHref(%q) = %q, want %q", tc.href, got, tc.want)
+			}
+		})
+	}
+}
+
+// slicesEqual compares two string slices for equality. Treats nil and empty
+// slices as equal.
+func slicesEqual(a, b []string) bool {
+	if len(a) == 0 && len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Implements #494 — Remote version listing from HashiCorp releases + local installed version listing.

## Changes

- `go/internal/list/` — `ListRemote()` and `ListLocal()`
- HTML parsing of releases.hashicorp.com index via `golang.org/x/net/html`
- Semver sorting via `hashicorp/go-version` (newest first by default)
- `TFENV_REVERSE_REMOTE` support for ascending order
- Pre-release versions included (filtering is caller responsibility)
- Local listing reads `ConfigDir/versions/` subdirectories
- User-Agent: `tfenv/go`, 30s HTTP timeout
- Comprehensive table-driven unit tests with `httptest`

## New Dependencies

- `hashicorp/go-version` v1.9.0
- `golang.org/x/net` v0.53.0

## Verification

- `go vet ./...` — clean
- `go test ./... -v` — all pass
- `go test -race ./...` — no races

Closes #494