### PR TITLE
feat: version resolution engine — latest, latest-allowed, min-required

### DIFF
--- a/go/internal/resolve/version.go
+++ b/go/internal/resolve/version.go
@@ -1,0 +1,365 @@
+// Version resolution engine — resolves version specifiers (latest,
+// latest:<regex>, latest-allowed, min-required, exact) into concrete
+// Terraform version numbers.
+package resolve
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	goversion "github.com/hashicorp/go-version"
+
+	"github.com/tfutils/tfenv/go/internal/config"
+	"github.com/tfutils/tfenv/go/internal/logging"
+)
+
+// ResolvedVersion holds the final resolved version and metadata about
+// where the specifier originated.
+type ResolvedVersion struct {
+	Version string // Concrete version (e.g. "1.5.7")
+	Source  string // Where the specifier came from
+}
+
+// exactVersionRe matches a version string that starts with digits in
+// semver-ish form: MAJOR.MINOR.PATCH with optional pre-release suffix.
+var exactVersionRe = regexp.MustCompile(`^\d+\.\d+\.\d+`)
+
+// requiredVersionRe extracts the constraint string from a
+// required_version line in an HCL or JSON file.  Matches both forms:
+//
+//	required_version = ">= 1.0.0"   (HCL)
+//	"required_version": ">= 1.3.0"  (JSON)
+var requiredVersionRe = regexp.MustCompile(
+	`"?required_version"?\s*[:=]\s*"([^"]+)"`,
+)
+
+// ResolveVersion takes a version specifier and the list of available
+// versions (from remote or local listing) and resolves it to a single
+// concrete version.
+//
+// Specifiers:
+//
+//   - "1.5.0"           — exact, returned as-is
+//   - "latest"          — newest stable (no pre-release)
+//   - "latest:<regex>"  — newest matching RE2 regex (pre-releases included)
+//   - "latest-allowed"  — newest satisfying required_version in .tf files
+//   - "min-required"    — minimum satisfying required_version in .tf files
+func ResolveVersion(
+	specifier string,
+	availableVersions []string,
+	source string,
+	cfg *config.Config,
+) (*ResolvedVersion, error) {
+	// Strip v prefix.
+	specifier = strings.TrimPrefix(specifier, "v")
+
+	logging.Debug("resolving version specifier",
+		"specifier", specifier, "candidates", len(availableVersions))
+
+	switch {
+	case specifier == "latest":
+		return resolveLatest(availableVersions, source)
+
+	case strings.HasPrefix(specifier, "latest:"):
+		pattern := strings.TrimPrefix(specifier, "latest:")
+		return resolveLatestRegex(pattern, availableVersions, source)
+
+	case specifier == "latest-allowed":
+		return resolveLatestAllowed(availableVersions, source, cfg)
+
+	case specifier == "min-required":
+		return resolveMinRequired(availableVersions, source, cfg)
+
+	case exactVersionRe.MatchString(specifier):
+		return &ResolvedVersion{
+			Version: specifier,
+			Source:  source,
+		}, nil
+
+	default:
+		return nil, fmt.Errorf(
+			"unrecognised version specifier: %q", specifier)
+	}
+}
+
+// resolveLatest returns the newest stable version (excluding
+// pre-releases: alpha, beta, rc).
+func resolveLatest(
+	versions []string, source string,
+) (*ResolvedVersion, error) {
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no versions available")
+	}
+
+	stable := filterStable(versions)
+	if len(stable) == 0 {
+		return nil, fmt.Errorf(
+			"no stable versions found among %d candidates",
+			len(versions))
+	}
+
+	newest := newestVersion(stable)
+	logging.Debug("resolved latest", "version", newest)
+
+	return &ResolvedVersion{Version: newest, Source: source}, nil
+}
+
+// resolveLatestRegex returns the newest version matching the given RE2
+// regex.  Pre-release versions are included if they match the pattern.
+func resolveLatestRegex(
+	pattern string, versions []string, source string,
+) (*ResolvedVersion, error) {
+	if len(versions) == 0 {
+		return nil, fmt.Errorf("no versions available")
+	}
+
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("invalid regex %q: %w", pattern, err)
+	}
+
+	var matched []string
+	for _, v := range versions {
+		if re.MatchString(v) {
+			matched = append(matched, v)
+		}
+	}
+
+	if len(matched) == 0 {
+		return nil, fmt.Errorf(
+			"no version matches regex %q among %d candidates",
+			pattern, len(versions))
+	}
+
+	newest := newestVersion(matched)
+	logging.Debug("resolved latest:<regex>",
+		"pattern", pattern, "version", newest)
+
+	return &ResolvedVersion{Version: newest, Source: source}, nil
+}
+
+// resolveLatestAllowed parses required_version from .tf files and
+// returns the latest available version satisfying the constraint.
+func resolveLatestAllowed(
+	versions []string, source string, cfg *config.Config,
+) (*ResolvedVersion, error) {
+	constraintStr, err := findRequiredVersion(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("latest-allowed: %w", err)
+	}
+
+	logging.Debug("parsed required_version constraint",
+		"constraint", constraintStr)
+
+	constraint, err := goversion.NewConstraint(constraintStr)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"parsing version constraint %q: %w", constraintStr, err)
+	}
+
+	stable := filterStable(versions)
+	matched := filterByConstraint(stable, constraint)
+
+	if len(matched) == 0 {
+		return nil, fmt.Errorf(
+			"no stable version satisfies constraint %q "+
+				"among %d candidates",
+			constraintStr, len(versions))
+	}
+
+	newest := newestVersion(matched)
+	logging.Debug("resolved latest-allowed",
+		"constraint", constraintStr, "version", newest)
+
+	return &ResolvedVersion{Version: newest, Source: source}, nil
+}
+
+// resolveMinRequired parses required_version from .tf files and returns
+// the minimum available version satisfying the constraint.
+func resolveMinRequired(
+	versions []string, source string, cfg *config.Config,
+) (*ResolvedVersion, error) {
+	constraintStr, err := findRequiredVersion(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("min-required: %w", err)
+	}
+
+	logging.Debug("parsed required_version constraint",
+		"constraint", constraintStr)
+
+	constraint, err := goversion.NewConstraint(constraintStr)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"parsing version constraint %q: %w", constraintStr, err)
+	}
+
+	stable := filterStable(versions)
+	matched := filterByConstraint(stable, constraint)
+
+	if len(matched) == 0 {
+		return nil, fmt.Errorf(
+			"no stable version satisfies constraint %q "+
+				"among %d candidates",
+			constraintStr, len(versions))
+	}
+
+	oldest := oldestVersion(matched)
+	logging.Debug("resolved min-required",
+		"constraint", constraintStr, "version", oldest)
+
+	return &ResolvedVersion{Version: oldest, Source: source}, nil
+}
+
+// -----------------------------------------------------------------------
+// HCL constraint discovery
+// -----------------------------------------------------------------------
+
+// findRequiredVersion searches .tf and .tf.json files in the working
+// directory for required_version attributes.  It collects all constraints
+// and joins them with commas so go-version can intersect them.
+func findRequiredVersion(cfg *config.Config) (string, error) {
+	dir := cfg.Dir
+	if dir == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return "", fmt.Errorf("determining working directory: %w", err)
+		}
+		dir = wd
+	}
+
+	logging.Debug("searching for required_version", "dir", dir)
+
+	patterns := []string{
+		filepath.Join(dir, "*.tf"),
+		filepath.Join(dir, "*.tf.json"),
+	}
+
+	var constraints []string
+
+	for _, pattern := range patterns {
+		matches, err := filepath.Glob(pattern)
+		if err != nil {
+			return "", fmt.Errorf("globbing %q: %w", pattern, err)
+		}
+
+		for _, path := range matches {
+			found, err := extractConstraints(path)
+			if err != nil {
+				logging.Debug("error reading tf file",
+					"path", path, "err", err)
+				continue
+			}
+			constraints = append(constraints, found...)
+		}
+	}
+
+	if len(constraints) == 0 {
+		return "", fmt.Errorf(
+			"no required_version constraint found in %s", dir)
+	}
+
+	// Join all found constraints with commas for intersection.
+	combined := strings.Join(constraints, ", ")
+	logging.Debug("combined constraints", "result", combined)
+
+	return combined, nil
+}
+
+// extractConstraints reads a single file and returns all
+// required_version constraint strings found.
+func extractConstraints(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %q: %w", path, err)
+	}
+
+	content := string(data)
+	var constraints []string
+
+	for _, line := range strings.Split(content, "\n") {
+		// Skip comment lines.
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "#") ||
+			strings.HasPrefix(trimmed, "//") {
+			continue
+		}
+
+		matches := requiredVersionRe.FindStringSubmatch(line)
+		if len(matches) >= 2 {
+			constraint := strings.TrimSpace(matches[1])
+			if constraint != "" {
+				constraints = append(constraints, constraint)
+			}
+		}
+	}
+
+	return constraints, nil
+}
+
+// -----------------------------------------------------------------------
+// Version filtering and sorting helpers
+// -----------------------------------------------------------------------
+
+// filterStable returns only versions with no pre-release segment.
+func filterStable(versions []string) []string {
+	var stable []string
+	for _, v := range versions {
+		parsed, err := goversion.NewVersion(v)
+		if err != nil {
+			continue
+		}
+		if parsed.Prerelease() == "" {
+			stable = append(stable, v)
+		}
+	}
+	return stable
+}
+
+// filterByConstraint returns versions satisfying the given constraint.
+func filterByConstraint(
+	versions []string, c goversion.Constraints,
+) []string {
+	var matched []string
+	for _, v := range versions {
+		parsed, err := goversion.NewVersion(v)
+		if err != nil {
+			continue
+		}
+		if c.Check(parsed) {
+			matched = append(matched, v)
+		}
+	}
+	return matched
+}
+
+// newestVersion returns the semver-highest version from a non-empty
+// slice.
+func newestVersion(versions []string) string {
+	sorted := sortedVersions(versions)
+	return sorted[len(sorted)-1]
+}
+
+// oldestVersion returns the semver-lowest version from a non-empty
+// slice.
+func oldestVersion(versions []string) string {
+	sorted := sortedVersions(versions)
+	return sorted[0]
+}
+
+// sortedVersions returns a copy sorted ascending by semver.
+func sortedVersions(versions []string) []string {
+	cp := make([]string, len(versions))
+	copy(cp, versions)
+
+	sort.Slice(cp, func(i, j int) bool {
+		vi, _ := goversion.NewVersion(cp[i])
+		vj, _ := goversion.NewVersion(cp[j])
+		return vi.LessThan(vj)
+	})
+
+	return cp
+}

--- a/go/internal/resolve/version_test.go
+++ b/go/internal/resolve/version_test.go
@@ -1,0 +1,851 @@
+package resolve
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tfutils/tfenv/go/internal/config"
+)
+
+// sampleVersions is a realistic set of available versions for tests.
+var sampleVersions = []string{
+	"1.0.0",
+	"1.0.1",
+	"1.1.0",
+	"1.2.0",
+	"1.3.0",
+	"1.4.0",
+	"1.4.1",
+	"1.5.0",
+	"1.5.1",
+	"1.5.2",
+	"1.5.3",
+	"1.5.4",
+	"1.5.5",
+	"1.5.6",
+	"1.5.7",
+	"1.6.0",
+	"1.6.1",
+	"1.6.2",
+	"1.6.3",
+	"1.6.4",
+	"1.6.5",
+	"1.6.6",
+	"1.7.0",
+	"1.7.1",
+	"1.7.2",
+	"1.7.3",
+	"1.7.4",
+	"1.7.5",
+	"1.8.0",
+	"1.8.1",
+	"1.8.2",
+	"1.8.3",
+	"1.8.4",
+	"1.8.5",
+	"1.9.0",
+	"1.9.1",
+	"1.9.2",
+	"1.9.3",
+	"1.9.4",
+	"1.9.5",
+	"1.9.6",
+	"1.9.7",
+	"1.9.8",
+	"1.10.0",
+	"1.10.1",
+	"1.10.2",
+	"1.10.3",
+	"2.0.0-alpha1",
+	"2.0.0-beta1",
+	"2.0.0-rc1",
+	"2.0.0",
+}
+
+// ---------------------------------------------------------------------------
+// Exact version resolution
+// ---------------------------------------------------------------------------
+
+func TestResolveVersion_Exact(t *testing.T) {
+	tests := []struct {
+		name      string
+		specifier string
+		want      string
+	}{
+		{"simple version", "1.5.0", "1.5.0"},
+		{"with patch", "1.5.7", "1.5.7"},
+		{"v prefix stripped", "v1.5.0", "1.5.0"},
+		{"pre-release exact", "2.0.0-alpha1", "2.0.0-alpha1"},
+		{"two-dot version", "1.10.3", "1.10.3"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ResolveVersion(
+				tc.specifier, sampleVersions, "test", &config.Config{})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Version != tc.want {
+				t.Errorf("got %q, want %q", result.Version, tc.want)
+			}
+			if result.Source != "test" {
+				t.Errorf("source = %q, want %q", result.Source, "test")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// latest — newest stable
+// ---------------------------------------------------------------------------
+
+func TestResolveVersion_Latest(t *testing.T) {
+	result, err := ResolveVersion(
+		"latest", sampleVersions, "test", &config.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "2.0.0" {
+		t.Errorf("got %q, want %q", result.Version, "2.0.0")
+	}
+}
+
+func TestResolveVersion_LatestExcludesPrerelease(t *testing.T) {
+	// Only pre-release versions + one stable.
+	versions := []string{
+		"1.0.0",
+		"2.0.0-alpha1",
+		"2.0.0-beta1",
+		"2.0.0-rc1",
+	}
+	result, err := ResolveVersion(
+		"latest", versions, "test", &config.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.0.0" {
+		t.Errorf("got %q, want %q — latest should exclude pre-releases",
+			result.Version, "1.0.0")
+	}
+}
+
+func TestResolveVersion_LatestAllPrerelease(t *testing.T) {
+	versions := []string{
+		"2.0.0-alpha1",
+		"2.0.0-beta1",
+	}
+	_, err := ResolveVersion(
+		"latest", versions, "test", &config.Config{})
+	if err == nil {
+		t.Fatal("expected error when all versions are pre-release")
+	}
+}
+
+func TestResolveVersion_LatestEmptyVersions(t *testing.T) {
+	_, err := ResolveVersion(
+		"latest", nil, "test", &config.Config{})
+	if err == nil {
+		t.Fatal("expected error with empty versions")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// latest:<regex> — regex matching
+// ---------------------------------------------------------------------------
+
+func TestResolveVersion_LatestRegex(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "match 1.5.x",
+			spec: `latest:^1\.5\.`,
+			want: "1.5.7",
+		},
+		{
+			name: "match 1.5.x does not match 1.50.x",
+			spec: `latest:^1\.5\.`,
+			want: "1.5.7",
+		},
+		{
+			name: "match 1.6.x",
+			spec: `latest:^1\.6\.`,
+			want: "1.6.6",
+		},
+		{
+			name: "match 2.x pre-releases included",
+			spec: `latest:^2\.0\.0`,
+			want: "2.0.0",
+		},
+		{
+			name: "match only rc",
+			spec: `latest:rc`,
+			want: "2.0.0-rc1",
+		},
+		{
+			name: "match alpha or beta",
+			spec: `latest:alpha|beta`,
+			want: "2.0.0-beta1",
+		},
+		{
+			name:    "no match",
+			spec:    `latest:^99\.`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid regex",
+			spec:    `latest:[invalid`,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ResolveVersion(
+				tc.spec, sampleVersions, "test", &config.Config{})
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Version != tc.want {
+				t.Errorf("got %q, want %q", result.Version, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveVersion_LatestRegex_DoesNotMatch150(t *testing.T) {
+	// Verify ^1\.5\. does NOT match 1.50.x (regex anchoring).
+	versions := []string{"1.5.0", "1.5.1", "1.50.0", "1.50.1"}
+	result, err := ResolveVersion(
+		`latest:^1\.5\.`, versions, "test", &config.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.5.1" {
+		t.Errorf("got %q, want %q — must not match 1.50.x",
+			result.Version, "1.5.1")
+	}
+}
+
+func TestResolveVersion_LatestRegexEmptyVersions(t *testing.T) {
+	_, err := ResolveVersion(
+		`latest:^1\.5\.`, nil, "test", &config.Config{})
+	if err == nil {
+		t.Fatal("expected error with empty versions")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// latest-allowed — constraint from .tf files
+// ---------------------------------------------------------------------------
+
+func TestResolveVersion_LatestAllowed(t *testing.T) {
+	tests := []struct {
+		name       string
+		tfContent  string
+		versions   []string
+		want       string
+		wantErr    bool
+		errContain string
+	}{
+		{
+			name: "pessimistic ~> 1.5.0",
+			tfContent: `terraform {
+  required_version = "~> 1.5.0"
+}`,
+			versions: sampleVersions,
+			want:     "1.5.7",
+		},
+		{
+			name: "range >= 1.0.0, < 2.0.0",
+			tfContent: `terraform {
+  required_version = ">= 1.0.0, < 2.0.0"
+}`,
+			versions: sampleVersions,
+			want:     "1.10.3",
+		},
+		{
+			name: "exact = 1.5.0",
+			tfContent: `terraform {
+  required_version = "= 1.5.0"
+}`,
+			versions: sampleVersions,
+			want:     "1.5.0",
+		},
+		{
+			name: "pessimistic ~> 1.5",
+			tfContent: `terraform {
+  required_version = "~> 1.5"
+}`,
+			versions: sampleVersions,
+			want:     "1.10.3",
+		},
+		{
+			name: "greater than or equal",
+			tfContent: `terraform {
+  required_version = ">= 1.9.0"
+}`,
+			versions: sampleVersions,
+			want:     "2.0.0",
+		},
+		{
+			name: "excludes pre-releases",
+			tfContent: `terraform {
+  required_version = ">= 1.0.0"
+}`,
+			versions: []string{
+				"1.0.0",
+				"2.0.0-alpha1",
+				"2.0.0-rc1",
+				"2.0.0",
+			},
+			want: "2.0.0",
+		},
+		{
+			name: "no matching version",
+			tfContent: `terraform {
+  required_version = ">= 99.0.0"
+}`,
+			versions: sampleVersions,
+			wantErr:  true,
+		},
+		{
+			name:       "no tf files",
+			tfContent:  "",
+			versions:   sampleVersions,
+			wantErr:    true,
+			errContain: "no required_version",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			if tc.tfContent != "" {
+				writeFile(t,
+					filepath.Join(tmp, "main.tf"),
+					tc.tfContent)
+			}
+
+			cfg := &config.Config{Dir: tmp}
+			result, err := ResolveVersion(
+				"latest-allowed", tc.versions, "test", cfg)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				if tc.errContain != "" {
+					if got := err.Error(); !contains(got, tc.errContain) {
+						t.Errorf("error %q should contain %q",
+							got, tc.errContain)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Version != tc.want {
+				t.Errorf("got %q, want %q", result.Version, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveVersion_LatestAllowed_MultipleFiles(t *testing.T) {
+	tmp := t.TempDir()
+
+	// First file constrains >= 1.5.0
+	writeFile(t, filepath.Join(tmp, "providers.tf"), `terraform {
+  required_version = ">= 1.5.0"
+}`)
+
+	// Second file constrains < 1.8.0
+	writeFile(t, filepath.Join(tmp, "backend.tf"), `terraform {
+  required_version = "< 1.8.0"
+}`)
+
+	cfg := &config.Config{Dir: tmp}
+	result, err := ResolveVersion(
+		"latest-allowed", sampleVersions, "test", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Intersection: >= 1.5.0 AND < 1.8.0 → newest is 1.7.5
+	if result.Version != "1.7.5" {
+		t.Errorf("got %q, want %q", result.Version, "1.7.5")
+	}
+}
+
+func TestResolveVersion_LatestAllowed_InvalidConstraint(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "main.tf"), `terraform {
+  required_version = "not-a-constraint"
+}`)
+
+	cfg := &config.Config{Dir: tmp}
+	_, err := ResolveVersion(
+		"latest-allowed", sampleVersions, "test", cfg)
+	if err == nil {
+		t.Fatal("expected error for invalid constraint")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// min-required — minimum satisfying version
+// ---------------------------------------------------------------------------
+
+func TestResolveVersion_MinRequired(t *testing.T) {
+	tests := []struct {
+		name      string
+		tfContent string
+		versions  []string
+		want      string
+		wantErr   bool
+	}{
+		{
+			name: "pessimistic ~> 1.5.0",
+			tfContent: `terraform {
+  required_version = "~> 1.5.0"
+}`,
+			versions: sampleVersions,
+			want:     "1.5.0",
+		},
+		{
+			name: "range >= 1.6.0, < 1.8.0",
+			tfContent: `terraform {
+  required_version = ">= 1.6.0, < 1.8.0"
+}`,
+			versions: sampleVersions,
+			want:     "1.6.0",
+		},
+		{
+			name: "exact = 1.5.0",
+			tfContent: `terraform {
+  required_version = "= 1.5.0"
+}`,
+			versions: sampleVersions,
+			want:     "1.5.0",
+		},
+		{
+			name: "no matching version",
+			tfContent: `terraform {
+  required_version = ">= 99.0.0"
+}`,
+			versions: sampleVersions,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			writeFile(t,
+				filepath.Join(tmp, "main.tf"),
+				tc.tfContent)
+
+			cfg := &config.Config{Dir: tmp}
+			result, err := ResolveVersion(
+				"min-required", tc.versions, "test", cfg)
+
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result.Version != tc.want {
+				t.Errorf("got %q, want %q", result.Version, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveVersion_MinRequired_MultipleFiles(t *testing.T) {
+	tmp := t.TempDir()
+
+	writeFile(t, filepath.Join(tmp, "providers.tf"), `terraform {
+  required_version = ">= 1.5.0"
+}`)
+
+	writeFile(t, filepath.Join(tmp, "backend.tf"), `terraform {
+  required_version = "< 1.8.0"
+}`)
+
+	cfg := &config.Config{Dir: tmp}
+	result, err := ResolveVersion(
+		"min-required", sampleVersions, "test", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Intersection: >= 1.5.0 AND < 1.8.0 → oldest is 1.5.0
+	if result.Version != "1.5.0" {
+		t.Errorf("got %q, want %q", result.Version, "1.5.0")
+	}
+}
+
+func TestResolveVersion_MinRequired_ExcludesPrerelease(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "main.tf"), `terraform {
+  required_version = ">= 1.0.0"
+}`)
+
+	versions := []string{
+		"2.0.0-alpha1",
+		"2.0.0-rc1",
+		"2.0.0",
+		"2.1.0",
+	}
+
+	cfg := &config.Config{Dir: tmp}
+	result, err := ResolveVersion(
+		"min-required", versions, "test", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "2.0.0" {
+		t.Errorf("got %q, want %q — should exclude pre-releases",
+			result.Version, "2.0.0")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+func TestResolveVersion_UnrecognisedSpecifier(t *testing.T) {
+	_, err := ResolveVersion(
+		"foobar", sampleVersions, "test", &config.Config{})
+	if err == nil {
+		t.Fatal("expected error for unrecognised specifier")
+	}
+}
+
+func TestResolveVersion_VPrefixStripped(t *testing.T) {
+	result, err := ResolveVersion(
+		"v1.5.0", sampleVersions, "test", &config.Config{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Version != "1.5.0" {
+		t.Errorf("got %q, want %q", result.Version, "1.5.0")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// findRequiredVersion tests
+// ---------------------------------------------------------------------------
+
+func TestFindRequiredVersion_SingleFile(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "main.tf"), `terraform {
+  required_version = "~> 1.5.0"
+}`)
+
+	cfg := &config.Config{Dir: tmp}
+	got, err := findRequiredVersion(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "~> 1.5.0" {
+		t.Errorf("got %q, want %q", got, "~> 1.5.0")
+	}
+}
+
+func TestFindRequiredVersion_MultipleFilesIntersected(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "a.tf"), `terraform {
+  required_version = ">= 1.5.0"
+}`)
+	writeFile(t, filepath.Join(tmp, "b.tf"), `terraform {
+  required_version = "< 2.0.0"
+}`)
+
+	cfg := &config.Config{Dir: tmp}
+	got, err := findRequiredVersion(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should contain both constraints joined by comma.
+	if !contains(got, ">= 1.5.0") || !contains(got, "< 2.0.0") {
+		t.Errorf("got %q, want both constraints combined", got)
+	}
+}
+
+func TestFindRequiredVersion_SkipsComments(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "main.tf"), `# required_version = ">= 0.12"
+// required_version = ">= 0.11"
+terraform {
+  required_version = "~> 1.5.0"
+}`)
+
+	cfg := &config.Config{Dir: tmp}
+	got, err := findRequiredVersion(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "~> 1.5.0" {
+		t.Errorf("got %q, want %q", got, "~> 1.5.0")
+	}
+}
+
+func TestFindRequiredVersion_TfJsonFile(t *testing.T) {
+	tmp := t.TempDir()
+	// .tf.json files can also have required_version.
+	writeFile(t, filepath.Join(tmp, "main.tf.json"),
+		`{ "terraform": { "required_version": ">= 1.3.0" } }`)
+
+	cfg := &config.Config{Dir: tmp}
+	got, err := findRequiredVersion(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !contains(got, ">= 1.3.0") {
+		t.Errorf("got %q, want to contain %q", got, ">= 1.3.0")
+	}
+}
+
+func TestFindRequiredVersion_NoFiles(t *testing.T) {
+	tmp := t.TempDir()
+	cfg := &config.Config{Dir: tmp}
+	_, err := findRequiredVersion(cfg)
+	if err == nil {
+		t.Fatal("expected error when no .tf files exist")
+	}
+}
+
+func TestFindRequiredVersion_NoConstraintInFiles(t *testing.T) {
+	tmp := t.TempDir()
+	writeFile(t, filepath.Join(tmp, "main.tf"), `resource "aws_instance" "web" {
+  ami = "ami-12345"
+}`)
+
+	cfg := &config.Config{Dir: tmp}
+	_, err := findRequiredVersion(cfg)
+	if err == nil {
+		t.Fatal("expected error when no required_version found")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// filterStable tests
+// ---------------------------------------------------------------------------
+
+func TestFilterStable(t *testing.T) {
+	input := []string{
+		"1.0.0",
+		"1.1.0-alpha1",
+		"1.1.0-beta1",
+		"1.1.0-rc1",
+		"1.1.0",
+		"2.0.0-alpha1",
+	}
+	got := filterStable(input)
+	want := []string{"1.0.0", "1.1.0"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i, v := range got {
+		if v != want[i] {
+			t.Errorf("got[%d] = %q, want %q", i, v, want[i])
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// newestVersion / oldestVersion tests
+// ---------------------------------------------------------------------------
+
+func TestNewestVersion(t *testing.T) {
+	versions := []string{"1.0.0", "1.2.0", "1.1.0", "0.9.0"}
+	got := newestVersion(versions)
+	if got != "1.2.0" {
+		t.Errorf("got %q, want %q", got, "1.2.0")
+	}
+}
+
+func TestOldestVersion(t *testing.T) {
+	versions := []string{"1.0.0", "1.2.0", "1.1.0", "0.9.0"}
+	got := oldestVersion(versions)
+	if got != "0.9.0" {
+		t.Errorf("got %q, want %q", got, "0.9.0")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractConstraints tests
+// ---------------------------------------------------------------------------
+
+func TestExtractConstraints(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "main.tf")
+
+	content := `terraform {
+  required_version = ">= 1.0.0, < 2.0.0"
+}
+
+# This module also requires:
+# required_version = ">= 0.12"
+
+resource "aws_instance" "web" {
+  ami = "ami-12345"
+}
+`
+	writeFile(t, path, content)
+
+	got, err := extractConstraints(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d constraints, want 1: %v", len(got), got)
+	}
+	if got[0] != ">= 1.0.0, < 2.0.0" {
+		t.Errorf("got %q, want %q", got[0], ">= 1.0.0, < 2.0.0")
+	}
+}
+
+func TestExtractConstraints_MultipleBlocks(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "versions.tf")
+
+	content := `terraform {
+  required_version = ">= 1.3.0"
+}
+
+# In another block context (unusual but valid for our grep)
+terraform {
+  required_version = "< 2.0.0"
+}
+`
+	writeFile(t, path, content)
+
+	got, err := extractConstraints(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d constraints, want 2: %v", len(got), got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// writeVersionFile is a test helper that creates a file. Reuses writeFile
+// from resolve_test.go (same package).
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) &&
+		(s == substr || len(s) > 0 && containsHelper(s, substr))
+}
+
+func containsHelper(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+// Ensure writeFile from the test package is reachable (it's in
+// resolve_test.go in the same package). We reference it above already.
+// If the build fails because writeFile is in a different test file,
+// the Go test runner compiles all _test.go files in a package together,
+// so it will be available.
+
+// ---------------------------------------------------------------------------
+// Integration: ResolveVersionFile → ResolveVersion pipeline
+// ---------------------------------------------------------------------------
+
+func TestResolveVersionFileThenResolveVersion(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	projectDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a version file specifying "latest".
+	writeFile(t, filepath.Join(projectDir, ".terraform-version"), "latest\n")
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       projectDir,
+	}
+
+	// Step 1: Resolve version file.
+	vr, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("ResolveVersionFile: %v", err)
+	}
+	if vr.Version != "latest" {
+		t.Fatalf("version file returned %q, want %q", vr.Version, "latest")
+	}
+
+	// Step 2: Resolve version specifier.
+	versions := []string{"1.0.0", "1.1.0", "2.0.0-rc1", "2.0.0"}
+	result, err := ResolveVersion(
+		vr.Version, versions, vr.Source, cfg)
+	if err != nil {
+		t.Fatalf("ResolveVersion: %v", err)
+	}
+	if result.Version != "2.0.0" {
+		t.Errorf("got %q, want %q", result.Version, "2.0.0")
+	}
+}
+
+func TestResolveVersionFileThenResolveVersion_LatestAllowed(t *testing.T) {
+	tmp := t.TempDir()
+	configDir := filepath.Join(tmp, "config")
+	projectDir := filepath.Join(tmp, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write version file.
+	writeFile(t, filepath.Join(projectDir, ".terraform-version"),
+		"latest-allowed\n")
+
+	// Write .tf file with constraint.
+	writeFile(t, filepath.Join(projectDir, "main.tf"), `terraform {
+  required_version = "~> 1.5.0"
+}`)
+
+	cfg := &config.Config{
+		ConfigDir: configDir,
+		Dir:       projectDir,
+	}
+
+	vr, err := ResolveVersionFile(cfg)
+	if err != nil {
+		t.Fatalf("ResolveVersionFile: %v", err)
+	}
+
+	result, err := ResolveVersion(
+		vr.Version, sampleVersions, vr.Source, cfg)
+	if err != nil {
+		t.Fatalf("ResolveVersion: %v", err)
+	}
+	if result.Version != "1.5.7" {
+		t.Errorf("got %q, want %q", result.Version, "1.5.7")
+	}
+}


### PR DESCRIPTION
Implements #495 — Version resolution engine resolving keywords and constraints to concrete versions.

## Changes

- `ResolveVersion()` in `go/internal/resolve/version.go`
- Specifiers: exact, `latest`, `latest:<regex>`, `latest-allowed`, `min-required`
- HCL `required_version` constraint parsing from `.tf` and `.tf.json` files
- Multi-file constraint intersection via `hashicorp/go-version`
- Pre-release filtering (excluded for `latest`/`latest-allowed`/`min-required`, included for `latest:<regex>`)
- Comprehensive table-driven tests (50+ test cases)
- Integration pipeline tests: `ResolveVersionFile` -> `ResolveVersion`

## Acceptance Criteria

- [x] Exact version specifiers (`1.5.0`) resolve to themselves
- [x] `latest` resolves to the newest stable (non-pre-release) version
- [x] `latest:<regex>` filters versions by RE2 regex and returns newest match
- [x] `latest:^1\.5` correctly matches only `1.5.x` versions (not `1.50.x`)
- [x] `latest-allowed` reads `required_version` from `.tf` files and returns the latest satisfying version
- [x] `min-required` reads `required_version` from `.tf` files and returns the minimum satisfying version
- [x] Multiple `required_version` constraints across multiple `.tf` files are intersected
- [x] Missing `.tf` files or missing `required_version` blocks produce clear errors
- [x] Pre-release versions are excluded by default for `latest`
- [x] Invalid regex patterns produce clear error messages
- [x] Invalid version constraints produce clear error messages
- [x] Version comparison uses `hashicorp/go-version` (not string comparison)
- [x] Comprehensive unit tests with table-driven patterns covering edge cases

Closes #495