### PR TITLE
feat: use command with previous version support

### DIFF
--- a/go/cmd/tfenv/main.go
+++ b/go/cmd/tfenv/main.go
@@ -17,6 +17,7 @@ import (
 
 	// Register subcommands via init().
 	_ "github.com/tfutils/tfenv/go/internal/install"
+	_ "github.com/tfutils/tfenv/go/internal/use"
 )
 
 // version is set at build time via -ldflags "-X main.version=...".

--- a/go/internal/use/use.go
+++ b/go/internal/use/use.go
@@ -1,0 +1,312 @@
+// Package use implements the tfenv use command — switching the default
+// Terraform version.
+package use
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/tfutils/tfenv/go/internal/cli"
+	"github.com/tfutils/tfenv/go/internal/config"
+	"github.com/tfutils/tfenv/go/internal/install"
+	"github.com/tfutils/tfenv/go/internal/list"
+	"github.com/tfutils/tfenv/go/internal/logging"
+	"github.com/tfutils/tfenv/go/internal/resolve"
+)
+
+func init() {
+	cli.Register("use", "Switch the default Terraform version", Run)
+}
+
+// Run implements the tfenv use command. It accepts zero or one argument:
+//   - No args: resolve version from the version file chain
+//   - One arg: use it as the version specifier
+//   - "-": switch to the previous version
+//
+// Returns 0 on success, 1 on error.
+func Run(args []string) int {
+	if len(args) > 1 {
+		logging.Error("usage: tfenv use [<version>]")
+		return 1
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		logging.Error("failed to load configuration", "err", err)
+		return 1
+	}
+
+	specifier, versionFileSource, err := resolveSpecifier(args, cfg)
+	if err != nil {
+		logging.Error("failed to determine version", "err", err)
+		return 1
+	}
+
+	logging.Debug("resolved specifier", "specifier", specifier, "source", versionFileSource)
+
+	// Resolve specifier to a concrete installed version.
+	version, err := resolveInstalledVersion(specifier, cfg)
+	if err != nil {
+		logging.Error("failed to resolve version", "err", err)
+		return 1
+	}
+
+	// Verify the binary exists and is executable.
+	if err := verifyBinary(cfg.ConfigDir, version); err != nil {
+		logging.Error("version verification failed", "err", err)
+		return 1
+	}
+
+	// Save previous version before switching.
+	versionFile := filepath.Join(cfg.ConfigDir, "version")
+	if err := savePreviousVersion(versionFile, version); err != nil {
+		logging.Warn("failed to save previous version", "err", err)
+	}
+
+	// Write new version atomically.
+	if err := atomicWriteFile(versionFile, version); err != nil {
+		logging.Error("failed to write version file", "err", err)
+		return 1
+	}
+
+	logging.Info(fmt.Sprintf("Switching default version to v%s", version))
+
+	// Warn if a .terraform-version file overrides the default.
+	defaultVersionFile := versionFile
+	if versionFileSource != "" && versionFileSource != defaultVersionFile {
+		logging.Warn(fmt.Sprintf(
+			"Default version file overridden by %s, changing the default version has no effect",
+			versionFileSource))
+	}
+
+	logging.Info(fmt.Sprintf(
+		"Default version (when not overridden by .terraform-version or TFENV_TERRAFORM_VERSION) is now: %s",
+		version))
+
+	return 0
+}
+
+// resolveSpecifier determines the version specifier from args or the
+// version file chain. Returns the specifier, the source of the version
+// file (for override detection), and any error.
+func resolveSpecifier(args []string, cfg *config.Config) (string, string, error) {
+	// Explicit argument provided.
+	if len(args) == 1 {
+		arg := args[0]
+
+		// Handle "tfenv use -" — switch to previous version.
+		if arg == "-" {
+			prev, err := readPreviousVersion(cfg.ConfigDir)
+			if err != nil {
+				return "", "", err
+			}
+			logging.Info("Switching to previous version", "version", prev)
+			return prev, "", nil
+		}
+
+		return arg, "", nil
+	}
+
+	// No argument — resolve from version file chain.
+	result, err := resolve.ResolveVersionFile(cfg)
+	if err != nil {
+		return "", "", fmt.Errorf("no version specified and no version file found: %w", err)
+	}
+
+	return result.Version, result.Source, nil
+}
+
+// readPreviousVersion reads the previous version from version.prev.
+func readPreviousVersion(configDir string) (string, error) {
+	prevFile := filepath.Join(configDir, "version.prev")
+
+	data, err := os.ReadFile(prevFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", fmt.Errorf("no previous version to switch to. Use tfenv use <version> first")
+		}
+		return "", fmt.Errorf("reading previous version file: %w", err)
+	}
+
+	version := strings.TrimSpace(strings.ReplaceAll(string(data), "\r", ""))
+	if version == "" {
+		return "", fmt.Errorf("previous version file is empty")
+	}
+
+	return version, nil
+}
+
+// resolveInstalledVersion resolves a specifier to a concrete version that
+// is installed locally. For keywords like "latest", it searches local
+// versions first and only falls back to remote + auto-install if enabled.
+func resolveInstalledVersion(specifier string, cfg *config.Config) (string, error) {
+	// Exact versions go straight to install check.
+	if isExactVersion(specifier) {
+		return ensureInstalled(specifier, specifier, cfg)
+	}
+
+	// For keywords, search locally installed versions first.
+	localVersions, err := list.ListLocal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("listing local versions: %w", err)
+	}
+
+	if len(localVersions) > 0 {
+		resolved, err := resolve.ResolveVersion(specifier, localVersions, "local", cfg)
+		if err == nil {
+			logging.Debug("resolved from local versions", "version", resolved.Version)
+			return resolved.Version, nil
+		}
+		logging.Debug("no local match for specifier", "specifier", specifier, "err", err)
+	}
+
+	// No local match — try remote + auto-install if enabled.
+	if !cfg.AutoInstall {
+		return "", fmt.Errorf(
+			"no installed version matches %q and TFENV_AUTO_INSTALL is not enabled",
+			specifier)
+	}
+
+	logging.Info("No installed versions match, attempting auto-install",
+		"specifier", specifier)
+
+	// Resolve via remote listing.
+	remoteVersions, err := list.ListRemote(cfg)
+	if err != nil {
+		return "", fmt.Errorf("fetching remote versions: %w", err)
+	}
+
+	resolved, err := resolve.ResolveVersion(specifier, remoteVersions, "remote", cfg)
+	if err != nil {
+		return "", fmt.Errorf("resolving version from remote: %w", err)
+	}
+
+	return ensureInstalled(resolved.Version, specifier, cfg)
+}
+
+// ensureInstalled checks if the version is installed, triggering
+// auto-install if configured. Returns the version string on success.
+func ensureInstalled(version, specifier string, cfg *config.Config) (string, error) {
+	if isVersionInstalled(cfg.ConfigDir, version) {
+		return version, nil
+	}
+
+	if !cfg.AutoInstall {
+		return "", fmt.Errorf(
+			"version %s is not installed. Install it with: tfenv install %s",
+			version, version)
+	}
+
+	logging.Info("Auto-installing missing version", "version", version)
+	exitCode := install.Run([]string{version})
+	if exitCode != 0 {
+		return "", fmt.Errorf("auto-install of version %s failed", version)
+	}
+
+	// Verify install succeeded.
+	if !isVersionInstalled(cfg.ConfigDir, version) {
+		return "", fmt.Errorf(
+			"version %s was installed but cannot be found — this should be impossible",
+			version)
+	}
+
+	return version, nil
+}
+
+// isExactVersion returns true if the specifier looks like a concrete version
+// (starts with a digit) rather than a keyword like "latest".
+func isExactVersion(specifier string) bool {
+	if len(specifier) == 0 {
+		return false
+	}
+	return specifier[0] >= '0' && specifier[0] <= '9'
+}
+
+// isVersionInstalled checks whether a specific Terraform version is installed
+// by looking for the terraform binary in the versions directory.
+func isVersionInstalled(configDir, version string) bool {
+	binaryName := "terraform"
+	if runtime.GOOS == "windows" {
+		binaryName = "terraform.exe"
+	}
+	binaryPath := filepath.Join(configDir, "versions", version, binaryName)
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+// verifyBinary checks that the terraform binary exists, is a regular file,
+// and is executable.
+func verifyBinary(configDir, version string) error {
+	binaryName := "terraform"
+	if runtime.GOOS == "windows" {
+		binaryName = "terraform.exe"
+	}
+	binaryPath := filepath.Join(configDir, "versions", version, binaryName)
+
+	info, err := os.Stat(binaryPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf(
+				"version directory for %s is present, but the terraform binary is not",
+				version)
+		}
+		return fmt.Errorf("checking terraform binary: %w", err)
+	}
+
+	if info.IsDir() {
+		return fmt.Errorf("terraform path is a directory, not a binary: %s", binaryPath)
+	}
+
+	// On Unix, check the executable bit.
+	if runtime.GOOS != "windows" {
+		if info.Mode()&0o111 == 0 {
+			return fmt.Errorf(
+				"version directory for %s is present, but the terraform binary is not executable",
+				version)
+		}
+	}
+
+	return nil
+}
+
+// savePreviousVersion reads the current version file and saves it to
+// version.prev if it differs from the new version being set.
+func savePreviousVersion(versionFile, newVersion string) error {
+	data, err := os.ReadFile(versionFile)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // No current version to save.
+		}
+		return fmt.Errorf("reading current version file: %w", err)
+	}
+
+	current := strings.TrimSpace(strings.ReplaceAll(string(data), "\r", ""))
+	if current == "" || current == newVersion {
+		return nil
+	}
+
+	logging.Debug("saving previous version", "version", current)
+	prevFile := versionFile + ".prev"
+	return atomicWriteFile(prevFile, current)
+}
+
+// atomicWriteFile writes content to path atomically by writing to a
+// temporary file and renaming.
+func atomicWriteFile(path, content string) error {
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, []byte(content+"\n"), 0o644); err != nil {
+		return fmt.Errorf("writing temporary file %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		// Clean up temp file on rename failure.
+		os.Remove(tmp)
+		return fmt.Errorf("renaming %s to %s: %w", tmp, path, err)
+	}
+	return nil
+}

--- a/go/internal/use/use_test.go
+++ b/go/internal/use/use_test.go
@@ -1,0 +1,404 @@
+package use
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/tfutils/tfenv/go/internal/config"
+)
+
+// setupTestDir creates a temporary config directory with the given installed
+// versions. Each version gets a directory with a fake terraform binary.
+func setupTestDir(t *testing.T, versions ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	versionsDir := filepath.Join(dir, "versions")
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatalf("creating versions dir: %v", err)
+	}
+
+	for _, v := range versions {
+		vDir := filepath.Join(versionsDir, v)
+		if err := os.MkdirAll(vDir, 0o755); err != nil {
+			t.Fatalf("creating version dir %s: %v", v, err)
+		}
+
+		binaryName := "terraform"
+		if runtime.GOOS == "windows" {
+			binaryName = "terraform.exe"
+		}
+		binaryPath := filepath.Join(vDir, binaryName)
+		if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\necho fake"), 0o755); err != nil {
+			t.Fatalf("writing fake binary %s: %v", binaryPath, err)
+		}
+	}
+
+	return dir
+}
+
+// testConfig returns a Config pointing at the test directory with
+// auto-install disabled by default.
+func testConfig(configDir string) *config.Config {
+	return &config.Config{
+		ConfigDir:   configDir,
+		AutoInstall: false,
+	}
+}
+
+func TestUseExactVersion(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0", "1.6.0")
+	cfg := testConfig(dir)
+
+	specifier := "1.5.0"
+	version, err := resolveInstalledVersion(specifier, cfg)
+	if err != nil {
+		t.Fatalf("resolveInstalledVersion(%q): %v", specifier, err)
+	}
+	if version != "1.5.0" {
+		t.Errorf("expected 1.5.0, got %s", version)
+	}
+
+	// Write the version file.
+	versionFile := filepath.Join(dir, "version")
+	if err := atomicWriteFile(versionFile, version); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+
+	data, err := os.ReadFile(versionFile)
+	if err != nil {
+		t.Fatalf("reading version file: %v", err)
+	}
+	got := strings.TrimSpace(string(data))
+	if got != "1.5.0" {
+		t.Errorf("version file contains %q, want %q", got, "1.5.0")
+	}
+}
+
+func TestUseLatestResolvesFromLocal(t *testing.T) {
+	dir := setupTestDir(t, "1.4.0", "1.5.0", "1.6.0")
+	cfg := testConfig(dir)
+
+	version, err := resolveInstalledVersion("latest", cfg)
+	if err != nil {
+		t.Fatalf("resolveInstalledVersion(latest): %v", err)
+	}
+	if version != "1.6.0" {
+		t.Errorf("expected 1.6.0, got %s", version)
+	}
+}
+
+func TestUseLatestRegexResolvesFromLocal(t *testing.T) {
+	dir := setupTestDir(t, "1.4.0", "1.5.1", "1.5.3", "1.6.0")
+	cfg := testConfig(dir)
+
+	version, err := resolveInstalledVersion("latest:^1\\.5", cfg)
+	if err != nil {
+		t.Fatalf("resolveInstalledVersion(latest:^1.5): %v", err)
+	}
+	if version != "1.5.3" {
+		t.Errorf("expected 1.5.3, got %s", version)
+	}
+}
+
+func TestUseDash(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0", "1.6.0")
+
+	// Write version.prev.
+	prevFile := filepath.Join(dir, "version.prev")
+	if err := os.WriteFile(prevFile, []byte("1.5.0\n"), 0o644); err != nil {
+		t.Fatalf("writing version.prev: %v", err)
+	}
+
+	prev, err := readPreviousVersion(dir)
+	if err != nil {
+		t.Fatalf("readPreviousVersion: %v", err)
+	}
+	if prev != "1.5.0" {
+		t.Errorf("expected 1.5.0, got %s", prev)
+	}
+}
+
+func TestUseDashWithCarriageReturn(t *testing.T) {
+	dir := setupTestDir(t)
+
+	prevFile := filepath.Join(dir, "version.prev")
+	if err := os.WriteFile(prevFile, []byte("1.5.0\r\n"), 0o644); err != nil {
+		t.Fatalf("writing version.prev: %v", err)
+	}
+
+	prev, err := readPreviousVersion(dir)
+	if err != nil {
+		t.Fatalf("readPreviousVersion: %v", err)
+	}
+	if prev != "1.5.0" {
+		t.Errorf("expected 1.5.0, got %s", prev)
+	}
+}
+
+func TestUseDashErrorNoPrev(t *testing.T) {
+	dir := setupTestDir(t)
+
+	_, err := readPreviousVersion(dir)
+	if err == nil {
+		t.Fatal("expected error when no version.prev exists")
+	}
+	if !strings.Contains(err.Error(), "no previous version") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestUseDashErrorEmptyPrev(t *testing.T) {
+	dir := setupTestDir(t)
+
+	prevFile := filepath.Join(dir, "version.prev")
+	if err := os.WriteFile(prevFile, []byte("\n"), 0o644); err != nil {
+		t.Fatalf("writing version.prev: %v", err)
+	}
+
+	_, err := readPreviousVersion(dir)
+	if err == nil {
+		t.Fatal("expected error when version.prev is empty")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestNoArgsReadsVersionFile(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0")
+	cfg := testConfig(dir)
+
+	// Set TFENV_TERRAFORM_VERSION in config to simulate env var.
+	cfg.TerraformVersion = "1.5.0"
+
+	specifier, source, err := resolveSpecifier(nil, cfg)
+	if err != nil {
+		t.Fatalf("resolveSpecifier: %v", err)
+	}
+	if specifier != "1.5.0" {
+		t.Errorf("expected specifier 1.5.0, got %s", specifier)
+	}
+	if source != "TFENV_TERRAFORM_VERSION" {
+		t.Errorf("expected source TFENV_TERRAFORM_VERSION, got %s", source)
+	}
+}
+
+func TestTooManyArgsError(t *testing.T) {
+	exitCode := Run([]string{"1.5.0", "1.6.0"})
+	if exitCode != 1 {
+		t.Errorf("expected exit code 1, got %d", exitCode)
+	}
+}
+
+func TestNotInstalledAutoInstallOff(t *testing.T) {
+	dir := setupTestDir(t) // No versions installed.
+	cfg := testConfig(dir)
+	cfg.AutoInstall = false
+
+	_, err := resolveInstalledVersion("1.5.0", cfg)
+	if err == nil {
+		t.Fatal("expected error for missing version")
+	}
+	if !strings.Contains(err.Error(), "not installed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "tfenv install") {
+		t.Errorf("error should suggest tfenv install: %v", err)
+	}
+}
+
+func TestVersionPrevUpdatedOnSwitch(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0", "1.6.0")
+
+	// Write current version file.
+	versionFile := filepath.Join(dir, "version")
+	if err := os.WriteFile(versionFile, []byte("1.5.0\n"), 0o644); err != nil {
+		t.Fatalf("writing version file: %v", err)
+	}
+
+	// Simulate switch to 1.6.0 — save previous.
+	if err := savePreviousVersion(versionFile, "1.6.0"); err != nil {
+		t.Fatalf("savePreviousVersion: %v", err)
+	}
+
+	// Check version.prev was written.
+	prevData, err := os.ReadFile(versionFile + ".prev")
+	if err != nil {
+		t.Fatalf("reading version.prev: %v", err)
+	}
+	got := strings.TrimSpace(string(prevData))
+	if got != "1.5.0" {
+		t.Errorf("version.prev contains %q, want %q", got, "1.5.0")
+	}
+}
+
+func TestVersionPrevNotUpdatedWhenSameVersion(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0")
+
+	versionFile := filepath.Join(dir, "version")
+	if err := os.WriteFile(versionFile, []byte("1.5.0\n"), 0o644); err != nil {
+		t.Fatalf("writing version file: %v", err)
+	}
+
+	// Switching to the same version should not create version.prev.
+	if err := savePreviousVersion(versionFile, "1.5.0"); err != nil {
+		t.Fatalf("savePreviousVersion: %v", err)
+	}
+
+	prevFile := versionFile + ".prev"
+	if _, err := os.Stat(prevFile); !os.IsNotExist(err) {
+		t.Errorf("version.prev should not exist when switching to same version")
+	}
+}
+
+func TestAtomicWriteFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "testfile")
+
+	if err := atomicWriteFile(path, "hello"); err != nil {
+		t.Fatalf("atomicWriteFile: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading file: %v", err)
+	}
+
+	if string(data) != "hello\n" {
+		t.Errorf("file contains %q, want %q", string(data), "hello\n")
+	}
+
+	// Verify temp file was cleaned up.
+	tmpPath := path + ".tmp"
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Errorf("temp file %s should not exist after successful write", tmpPath)
+	}
+}
+
+func TestVerifyBinary(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0")
+
+	// Should succeed for an installed version with executable binary.
+	if err := verifyBinary(dir, "1.5.0"); err != nil {
+		t.Errorf("verifyBinary should succeed: %v", err)
+	}
+}
+
+func TestVerifyBinaryMissing(t *testing.T) {
+	dir := setupTestDir(t)
+
+	// Create version dir without binary.
+	vDir := filepath.Join(dir, "versions", "1.5.0")
+	if err := os.MkdirAll(vDir, 0o755); err != nil {
+		t.Fatalf("creating version dir: %v", err)
+	}
+
+	err := verifyBinary(dir, "1.5.0")
+	if err == nil {
+		t.Fatal("expected error for missing binary")
+	}
+	if !strings.Contains(err.Error(), "binary is not") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestVerifyBinaryNotExecutable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("executable bit not meaningful on Windows")
+	}
+
+	dir := setupTestDir(t)
+
+	vDir := filepath.Join(dir, "versions", "1.5.0")
+	if err := os.MkdirAll(vDir, 0o755); err != nil {
+		t.Fatalf("creating version dir: %v", err)
+	}
+
+	// Write binary without executable permission.
+	binaryPath := filepath.Join(vDir, "terraform")
+	if err := os.WriteFile(binaryPath, []byte("fake"), 0o644); err != nil {
+		t.Fatalf("writing binary: %v", err)
+	}
+
+	err := verifyBinary(dir, "1.5.0")
+	if err == nil {
+		t.Fatal("expected error for non-executable binary")
+	}
+	if !strings.Contains(err.Error(), "not executable") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestIsExactVersion(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"1.5.0", true},
+		{"0.12.31", true},
+		{"1.5.0-rc1", true},
+		{"latest", false},
+		{"latest:^1.5", false},
+		{"latest-allowed", false},
+		{"min-required", false},
+		{"", false},
+	}
+	for _, tc := range tests {
+		got := isExactVersion(tc.input)
+		if got != tc.want {
+			t.Errorf("isExactVersion(%q) = %v, want %v", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestResolveSpecifierDash(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0")
+
+	// Write version.prev.
+	prevFile := filepath.Join(dir, "version.prev")
+	if err := os.WriteFile(prevFile, []byte("1.5.0\n"), 0o644); err != nil {
+		t.Fatalf("writing version.prev: %v", err)
+	}
+
+	cfg := testConfig(dir)
+	specifier, _, err := resolveSpecifier([]string{"-"}, cfg)
+	if err != nil {
+		t.Fatalf("resolveSpecifier(-): %v", err)
+	}
+	if specifier != "1.5.0" {
+		t.Errorf("expected 1.5.0, got %s", specifier)
+	}
+}
+
+func TestSavePreviousVersionNoExistingFile(t *testing.T) {
+	dir := t.TempDir()
+	versionFile := filepath.Join(dir, "version")
+
+	// No existing version file — should not error, should not create .prev.
+	if err := savePreviousVersion(versionFile, "1.5.0"); err != nil {
+		t.Fatalf("savePreviousVersion: %v", err)
+	}
+
+	prevFile := versionFile + ".prev"
+	if _, err := os.Stat(prevFile); !os.IsNotExist(err) {
+		t.Errorf("version.prev should not exist when no current version file")
+	}
+}
+
+func TestLatestNoLocalMatchAutoInstallOff(t *testing.T) {
+	dir := setupTestDir(t) // No versions installed.
+	cfg := testConfig(dir)
+	cfg.AutoInstall = false
+
+	_, err := resolveInstalledVersion("latest", cfg)
+	if err == nil {
+		t.Fatal("expected error when no local versions match and auto-install is off")
+	}
+	if !strings.Contains(err.Error(), "TFENV_AUTO_INSTALL") {
+		t.Errorf("error should mention TFENV_AUTO_INSTALL: %v", err)
+	}
+}


### PR DESCRIPTION
Implements #498 — tfenv use command for switching Terraform versions.

## Changes

- `internal/use/` package with `Run` handler registered via `cli.Register`
- Version resolution from locally installed versions first (remote only with auto-install)
- `use -` for previous version switching via `version.prev` file
- Atomic version file writing (write tmp + rename)
- Auto-install integration via `install.Run`
- `version.prev` tracking (skipped when same version)
- Binary existence and executable verification
- Override warning when `.terraform-version` overrides default
- 20 unit tests covering all acceptance criteria

## Acceptance Criteria Status

- [x] `tfenv use 1.5.0` sets the default version
- [x] `tfenv use latest` resolves from local installed versions
- [x] `tfenv use latest:^1.5` resolves latest matching regex
- [x] `tfenv use -` switches to previous version
- [x] `tfenv use -` errors clearly when no previous version
- [x] No args reads from version file chain / TFENV_TERRAFORM_VERSION
- [x] Error if version not installed (auto-install off)
- [x] Auto-install triggers when version missing and enabled
- [x] version.prev updated on switch
- [x] version.prev NOT updated when same version
- [x] Default version file updated atomically
- [x] Warning when .terraform-version overrides default
- [x] Terraform binary verified present and executable
- [x] Exit code 0 on success, non-zero on failure
- [x] Confirmation message printed on success

Closes #498