### PR TITLE
[STACKED] feat: list & list-remote commands with architecture detection

### DIFF
--- a/go/cmd/tfenv/main.go
+++ b/go/cmd/tfenv/main.go
@@ -17,6 +17,7 @@ import (
 
 	// Register subcommands via init().
 	_ "github.com/tfutils/tfenv/go/internal/install"
+	_ "github.com/tfutils/tfenv/go/internal/list"
 	_ "github.com/tfutils/tfenv/go/internal/use"
 )
 

--- a/go/internal/list/command.go
+++ b/go/internal/list/command.go
@@ -1,0 +1,174 @@
+package list
+
+import (
+	"debug/elf"
+	"debug/macho"
+	"debug/pe"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/tfutils/tfenv/go/internal/cli"
+	"github.com/tfutils/tfenv/go/internal/config"
+	"github.com/tfutils/tfenv/go/internal/logging"
+	"github.com/tfutils/tfenv/go/internal/resolve"
+)
+
+func init() {
+	cli.Register("list", "List installed Terraform versions", RunList)
+	cli.Register("list-remote", "List installable Terraform versions", RunListRemote)
+}
+
+// RunList implements the tfenv list command. It displays all locally installed
+// Terraform versions with architecture and active-version marking.
+// Returns 0 on success, 1 on error.
+func RunList(args []string) int {
+	if len(args) > 0 {
+		logging.Error("usage: tfenv list")
+		return 1
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		logging.Error("failed to load configuration", "err", err)
+		return 1
+	}
+
+	versions, err := ListLocal(cfg)
+	if err != nil {
+		logging.Error("failed to list installed versions", "err", err)
+		return 1
+	}
+
+	if len(versions) == 0 {
+		fmt.Fprintln(os.Stderr, "No versions available. Please install one with: tfenv install")
+		return 1
+	}
+
+	// Resolve active version (may fail if no version is set).
+	var activeVersion, versionSource string
+	result, err := resolve.ResolveVersionFile(cfg)
+	if err == nil {
+		activeVersion = result.Version
+		versionSource = result.Source
+	}
+
+	defaultSet := false
+	for _, v := range versions {
+		binaryPath := filepath.Join(cfg.ConfigDir, "versions", v, "terraform")
+		arch := detectBinaryArch(binaryPath)
+		if v == activeVersion {
+			fmt.Fprintf(os.Stdout, "* %s (%s) (set by %s)\n", v, arch, versionSource)
+			defaultSet = true
+		} else {
+			fmt.Fprintf(os.Stdout, "  %s (%s)\n", v, arch)
+		}
+	}
+
+	if !defaultSet {
+		logging.Info("No default set. Set with 'tfenv use <version>'")
+	}
+
+	return 0
+}
+
+// RunListRemote implements the tfenv list-remote command. It displays
+// available Terraform versions from the remote mirror, optionally
+// filtered by a regex pattern.
+// Returns 0 on success, 1 on error.
+func RunListRemote(args []string) int {
+	if len(args) > 1 {
+		logging.Error("usage: tfenv list-remote [<regex>]")
+		return 1
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		logging.Error("failed to load configuration", "err", err)
+		return 1
+	}
+
+	versions, err := ListRemote(cfg)
+	if err != nil {
+		logging.Error("failed to list remote versions", "err", err)
+		return 1
+	}
+
+	// Apply regex filter if provided.
+	if len(args) == 1 {
+		re, err := regexp.Compile(args[0])
+		if err != nil {
+			logging.Error("invalid regex", "pattern", args[0], "err", err)
+			return 1
+		}
+		var filtered []string
+		for _, v := range versions {
+			if re.MatchString(v) {
+				filtered = append(filtered, v)
+			}
+		}
+		versions = filtered
+	}
+
+	for _, v := range versions {
+		fmt.Fprintln(os.Stdout, v)
+	}
+
+	return 0
+}
+
+// detectBinaryArch inspects the binary at the given path and returns its
+// architecture string. It tries ELF, Mach-O, and PE formats in order.
+// Returns "unknown" if the file cannot be read or its format is not recognised.
+func detectBinaryArch(binaryPath string) string {
+	// Try ELF (Linux).
+	if f, err := elf.Open(binaryPath); err == nil {
+		machine := f.Machine
+		f.Close()
+		switch machine {
+		case elf.EM_X86_64:
+			return "amd64"
+		case elf.EM_AARCH64:
+			return "arm64"
+		case elf.EM_386:
+			return "386"
+		case elf.EM_ARM:
+			return "arm"
+		default:
+			return "unknown"
+		}
+	}
+
+	// Try Mach-O (macOS).
+	if f, err := macho.Open(binaryPath); err == nil {
+		cpu := f.Cpu
+		f.Close()
+		switch cpu {
+		case macho.CpuAmd64:
+			return "amd64"
+		case macho.CpuArm64:
+			return "arm64"
+		default:
+			return "unknown"
+		}
+	}
+
+	// Try PE (Windows).
+	if f, err := pe.Open(binaryPath); err == nil {
+		machine := f.Machine
+		f.Close()
+		switch machine {
+		case pe.IMAGE_FILE_MACHINE_AMD64:
+			return "amd64"
+		case pe.IMAGE_FILE_MACHINE_ARM64:
+			return "arm64"
+		case pe.IMAGE_FILE_MACHINE_I386:
+			return "386"
+		default:
+			return "unknown"
+		}
+	}
+
+	return "unknown"
+}

--- a/go/internal/list/command_test.go
+++ b/go/internal/list/command_test.go
@@ -1,0 +1,435 @@
+package list
+
+import (
+	"bytes"
+	"debug/elf"
+	"debug/macho"
+	"debug/pe"
+	"encoding/binary"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- Test helpers for creating minimal binary files ---
+
+// createTestELF writes a minimal valid ELF64 binary with the given machine type.
+func createTestELF(t *testing.T, path string, machine elf.Machine) {
+	t.Helper()
+	hdr := elf.Header64{
+		Ident: [elf.EI_NIDENT]byte{
+			0: 0x7f, 1: 'E', 2: 'L', 3: 'F',
+			4: 2, // ELFCLASS64
+			5: 1, // ELFDATA2LSB
+			6: 1, // EV_CURRENT
+		},
+		Type:    2, // ET_EXEC
+		Machine: uint16(machine),
+		Version: 1,
+		Ehsize:  64,
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := binary.Write(f, binary.LittleEndian, &hdr); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// testMachOHeader64 is the raw layout of a 64-bit Mach-O header.
+type testMachOHeader64 struct {
+	Magic    uint32
+	CpuType  uint32
+	SubType  uint32
+	FileType uint32
+	NCmds    uint32
+	CmdsSize uint32
+	Flags    uint32
+	Reserved uint32
+}
+
+// createTestMachO writes a minimal valid 64-bit little-endian Mach-O binary.
+func createTestMachO(t *testing.T, path string, cpu macho.Cpu) {
+	t.Helper()
+	hdr := testMachOHeader64{
+		Magic:    0xFEEDFACF, // MH_MAGIC_64
+		CpuType:  uint32(cpu),
+		SubType:  3, // CPU_SUBTYPE_ALL
+		FileType: 2, // MH_EXECUTE
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+	if err := binary.Write(f, binary.LittleEndian, &hdr); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// createTestPE writes a minimal valid PE binary with the given machine type.
+func createTestPE(t *testing.T, path string, machine uint16) {
+	t.Helper()
+	// Minimal PE: DOS header (96 bytes) + PE signature (4) + COFF header (20).
+	peOffset := uint32(96)
+	size := int(peOffset) + 4 + 20
+	buf := make([]byte, size)
+
+	// DOS magic.
+	buf[0] = 'M'
+	buf[1] = 'Z'
+
+	// PE offset at 0x3C.
+	binary.LittleEndian.PutUint32(buf[0x3C:], peOffset)
+
+	// PE signature.
+	copy(buf[peOffset:], []byte{'P', 'E', 0, 0})
+
+	// COFF Machine field (first 2 bytes of COFF header).
+	binary.LittleEndian.PutUint16(buf[peOffset+4:], machine)
+
+	if err := os.WriteFile(path, buf, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// captureStdout redirects os.Stdout to a pipe, runs fn, and returns
+// whatever was written. Not safe for use with t.Parallel.
+func captureStdout(fn func()) string {
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	os.Stdout = w
+	fn()
+	w.Close()
+	os.Stdout = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+// captureStderr redirects os.Stderr to a pipe, runs fn, and returns
+// whatever was written. Not safe for use with t.Parallel.
+func captureStderr(fn func()) string {
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+	os.Stderr = w
+	fn()
+	w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	return buf.String()
+}
+
+// --- detectBinaryArch tests ---
+
+func TestDetectBinaryArch_ELF(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		machine elf.Machine
+		want    string
+	}{
+		{"amd64", elf.EM_X86_64, "amd64"},
+		{"arm64", elf.EM_AARCH64, "arm64"},
+		{"386", elf.EM_386, "386"},
+		{"arm", elf.EM_ARM, "arm"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "binary")
+			createTestELF(t, path, tc.machine)
+			got := detectBinaryArch(path)
+			if got != tc.want {
+				t.Errorf("detectBinaryArch() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectBinaryArch_MachO(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cpu  macho.Cpu
+		want string
+	}{
+		{"amd64", macho.CpuAmd64, "amd64"},
+		{"arm64", macho.CpuArm64, "arm64"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "binary")
+			createTestMachO(t, path, tc.cpu)
+			got := detectBinaryArch(path)
+			if got != tc.want {
+				t.Errorf("detectBinaryArch() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectBinaryArch_PE(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		machine uint16
+		want    string
+	}{
+		{"amd64", pe.IMAGE_FILE_MACHINE_AMD64, "amd64"},
+		{"arm64", pe.IMAGE_FILE_MACHINE_ARM64, "arm64"},
+		{"386", pe.IMAGE_FILE_MACHINE_I386, "386"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			path := filepath.Join(t.TempDir(), "binary")
+			createTestPE(t, path, tc.machine)
+			got := detectBinaryArch(path)
+			if got != tc.want {
+				t.Errorf("detectBinaryArch() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDetectBinaryArch_Nonexistent(t *testing.T) {
+	t.Parallel()
+	got := detectBinaryArch("/nonexistent/path/binary")
+	if got != "unknown" {
+		t.Errorf("detectBinaryArch(nonexistent) = %q, want %q", got, "unknown")
+	}
+}
+
+func TestDetectBinaryArch_InvalidFile(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "binary")
+	if err := os.WriteFile(path, []byte("not a binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got := detectBinaryArch(path)
+	if got != "unknown" {
+		t.Errorf("detectBinaryArch(invalid) = %q, want %q", got, "unknown")
+	}
+}
+
+// --- RunList tests ---
+
+func TestRunList_MultipleVersions(t *testing.T) {
+	dir := t.TempDir()
+	versionsDir := filepath.Join(dir, "versions")
+
+	for _, v := range []string{"1.5.0", "1.6.0", "1.4.0"} {
+		vDir := filepath.Join(versionsDir, v)
+		if err := os.MkdirAll(vDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		createTestELF(t, filepath.Join(vDir, "terraform"), elf.EM_X86_64)
+	}
+
+	t.Setenv("TFENV_CONFIG_DIR", dir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "1.5.0")
+
+	var code int
+	stdout := captureStdout(func() {
+		code = RunList(nil)
+	})
+	if code != 0 {
+		t.Fatalf("RunList() returned %d, want 0", code)
+	}
+
+	lines := strings.Split(strings.TrimRight(stdout, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), stdout)
+	}
+
+	// Sorted newest first: 1.6.0, 1.5.0 (active), 1.4.0.
+	if !strings.HasPrefix(lines[0], "  1.6.0 (amd64)") {
+		t.Errorf("line 0 = %q, want prefix '  1.6.0 (amd64)'", lines[0])
+	}
+	if !strings.HasPrefix(lines[1], "* 1.5.0 (amd64)") {
+		t.Errorf("line 1 = %q, want prefix '* 1.5.0 (amd64)'", lines[1])
+	}
+	if !strings.Contains(lines[1], "(set by TFENV_TERRAFORM_VERSION)") {
+		t.Errorf("line 1 = %q, want to contain '(set by TFENV_TERRAFORM_VERSION)'", lines[1])
+	}
+	if !strings.HasPrefix(lines[2], "  1.4.0 (amd64)") {
+		t.Errorf("line 2 = %q, want prefix '  1.4.0 (amd64)'", lines[2])
+	}
+}
+
+func TestRunList_NoVersions(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("TFENV_CONFIG_DIR", dir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "")
+	t.Setenv("TFENV_DIR", dir)
+
+	var code int
+	stderr := captureStderr(func() {
+		code = RunList(nil)
+	})
+	if code != 1 {
+		t.Errorf("RunList() returned %d, want 1", code)
+	}
+	if !strings.Contains(stderr, "No versions available") {
+		t.Errorf("stderr = %q, want to contain 'No versions available'", stderr)
+	}
+}
+
+func TestRunList_NoDefault(t *testing.T) {
+	dir := t.TempDir()
+	versionsDir := filepath.Join(dir, "versions")
+	vDir := filepath.Join(versionsDir, "1.5.0")
+	if err := os.MkdirAll(vDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	createTestELF(t, filepath.Join(vDir, "terraform"), elf.EM_X86_64)
+
+	t.Setenv("TFENV_CONFIG_DIR", dir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "")
+	t.Setenv("TFENV_DIR", dir)
+	t.Setenv("HOME", dir)
+
+	var code int
+	stdout := captureStdout(func() {
+		code = RunList(nil)
+	})
+	if code != 0 {
+		t.Fatalf("RunList() returned %d, want 0", code)
+	}
+	if !strings.Contains(stdout, "  1.5.0 (amd64)") {
+		t.Errorf("stdout = %q, want to contain '  1.5.0 (amd64)'", stdout)
+	}
+	if strings.Contains(stdout, "*") {
+		t.Errorf("stdout = %q, should not contain '*' (no default set)", stdout)
+	}
+}
+
+func TestRunList_UsageError(t *testing.T) {
+	code := RunList([]string{"extra"})
+	if code != 1 {
+		t.Errorf("RunList(extra) returned %d, want 1", code)
+	}
+}
+
+// --- RunListRemote tests ---
+
+func TestRunListRemote_AllVersions(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><body>
+			<a href="/terraform/1.6.0/">terraform_1.6.0</a>
+			<a href="/terraform/1.5.0/">terraform_1.5.0</a>
+			<a href="/terraform/1.4.0/">terraform_1.4.0</a>
+		</body></html>`))
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	t.Setenv("TFENV_CONFIG_DIR", dir)
+	t.Setenv("TFENV_REMOTE", server.URL)
+
+	var code int
+	stdout := captureStdout(func() {
+		code = RunListRemote(nil)
+	})
+	if code != 0 {
+		t.Fatalf("RunListRemote() returned %d, want 0", code)
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), stdout)
+	}
+	if lines[0] != "1.6.0" {
+		t.Errorf("line 0 = %q, want %q", lines[0], "1.6.0")
+	}
+	if lines[1] != "1.5.0" {
+		t.Errorf("line 1 = %q, want %q", lines[1], "1.5.0")
+	}
+	if lines[2] != "1.4.0" {
+		t.Errorf("line 2 = %q, want %q", lines[2], "1.4.0")
+	}
+}
+
+func TestRunListRemote_WithRegex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><body>
+			<a href="/terraform/1.6.0/">terraform_1.6.0</a>
+			<a href="/terraform/1.5.3/">terraform_1.5.3</a>
+			<a href="/terraform/1.5.0/">terraform_1.5.0</a>
+			<a href="/terraform/1.4.0/">terraform_1.4.0</a>
+		</body></html>`))
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	t.Setenv("TFENV_CONFIG_DIR", dir)
+	t.Setenv("TFENV_REMOTE", server.URL)
+
+	var code int
+	stdout := captureStdout(func() {
+		code = RunListRemote([]string{`^1\.5`})
+	})
+	if code != 0 {
+		t.Fatalf("RunListRemote(regex) returned %d, want 0", code)
+	}
+
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 lines, got %d: %q", len(lines), stdout)
+	}
+	if lines[0] != "1.5.3" {
+		t.Errorf("line 0 = %q, want %q", lines[0], "1.5.3")
+	}
+	if lines[1] != "1.5.0" {
+		t.Errorf("line 1 = %q, want %q", lines[1], "1.5.0")
+	}
+}
+
+func TestRunListRemote_InvalidRegex(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(`<html><body>
+			<a href="/terraform/1.5.0/">terraform_1.5.0</a>
+		</body></html>`))
+	}))
+	t.Cleanup(server.Close)
+
+	dir := t.TempDir()
+	t.Setenv("TFENV_CONFIG_DIR", dir)
+	t.Setenv("TFENV_REMOTE", server.URL)
+
+	code := RunListRemote([]string{"[invalid"})
+	if code != 1 {
+		t.Errorf("RunListRemote(invalid regex) returned %d, want 1", code)
+	}
+}
+
+func TestRunListRemote_UsageError(t *testing.T) {
+	code := RunListRemote([]string{"arg1", "arg2"})
+	if code != 1 {
+		t.Errorf("RunListRemote(too many args) returned %d, want 1", code)
+	}
+}


### PR DESCRIPTION
Implements #499 — tfenv list and tfenv list-remote commands for the Go edition.

## Changes

- **list command**: displays installed versions sorted by semver (newest first), with binary architecture detection and active version marking (`*` with version source)
- **list-remote command**: displays available remote versions with optional regex filter (`tfenv list-remote ^1\.5`)
- **Architecture detection**: inspects binary headers via `debug/elf`, `debug/macho`, `debug/pe` stdlib packages (no external `file` command dependency)
- **CLI registration**: both commands registered via `init()` with blank import in main.go

## Tests

- Architecture detection for ELF (amd64, arm64, 386, arm), Mach-O (amd64, arm64), PE (amd64, arm64, 386)
- Edge cases: nonexistent file, invalid binary → "unknown"
- RunList: multiple versions with active marking, no versions (error), no default set, usage error
- RunListRemote: all versions, regex filter, invalid regex, usage error

## Verification

```
go vet ./...        # clean
go test ./... -v    # all pass
go test -race ./... # no races
./tfenv-go help     # shows list, list-remote
```

Closes #499