### PR TITLE
feat: uninstall command with multi-version support

### DIFF
--- a/go/cmd/tfenv/main.go
+++ b/go/cmd/tfenv/main.go
@@ -18,6 +18,7 @@ import (
 	// Register subcommands via init().
 	_ "github.com/tfutils/tfenv/go/internal/install"
 	_ "github.com/tfutils/tfenv/go/internal/list"
+	_ "github.com/tfutils/tfenv/go/internal/uninstall"
 	_ "github.com/tfutils/tfenv/go/internal/use"
 )
 

--- a/go/internal/uninstall/uninstall.go
+++ b/go/internal/uninstall/uninstall.go
@@ -1,0 +1,204 @@
+// Package uninstall implements the tfenv uninstall command — removing
+// installed Terraform versions from the local filesystem.
+package uninstall
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/tfutils/tfenv/go/internal/cli"
+	"github.com/tfutils/tfenv/go/internal/config"
+	"github.com/tfutils/tfenv/go/internal/list"
+	"github.com/tfutils/tfenv/go/internal/logging"
+	"github.com/tfutils/tfenv/go/internal/resolve"
+)
+
+func init() {
+	cli.Register("uninstall", "Uninstall a specific version of Terraform", Run)
+}
+
+// Run implements the tfenv uninstall command. It accepts zero or more
+// arguments:
+//   - No args: resolve version from env var or version file chain
+//   - One or more args: each is a version specifier to uninstall
+//
+// Returns 0 on full success, 1 if any uninstall failed.
+func Run(args []string) int {
+	cfg, err := config.Load()
+	if err != nil {
+		logging.Error("failed to load configuration", "err", err)
+		return 1
+	}
+
+	versions, err := collectVersions(args, cfg)
+	if err != nil {
+		logging.Error("failed to determine version to uninstall", "err", err)
+		return 1
+	}
+
+	failures := 0
+	for _, specifier := range versions {
+		if err := uninstallSingle(specifier, cfg); err != nil {
+			logging.Error("failed to uninstall version",
+				"specifier", specifier, "err", err)
+			failures++
+		}
+	}
+
+	// Post-cleanup: remove versions/ dir if empty (best-effort).
+	versionsDir := filepath.Join(cfg.ConfigDir, "versions")
+	_ = os.Remove(versionsDir)
+
+	if failures > 0 {
+		return 1
+	}
+	return 0
+}
+
+// collectVersions determines the list of version specifiers to uninstall.
+// Priority: command-line args > TFENV_TERRAFORM_VERSION > version file chain.
+func collectVersions(args []string, cfg *config.Config) ([]string, error) {
+	if len(args) > 0 {
+		return args, nil
+	}
+
+	// No args — try env var.
+	if cfg.TerraformVersion != "" {
+		version := strings.TrimSpace(strings.TrimPrefix(cfg.TerraformVersion, "v"))
+		return []string{version}, nil
+	}
+
+	// No env var — try version file chain.
+	result, err := resolve.ResolveVersionFile(cfg)
+	if err != nil {
+		return nil, fmt.Errorf(
+			"no version specified on command line, "+
+				"no TFENV_TERRAFORM_VERSION set, and no version file found: %w", err)
+	}
+
+	return []string{result.Version}, nil
+}
+
+// uninstallSingle handles the uninstall of one version specifier.
+// It resolves keywords against locally installed versions, validates
+// the version string, and removes the version directory.
+func uninstallSingle(specifier string, cfg *config.Config) error {
+	specifier = strings.TrimSpace(strings.TrimPrefix(specifier, "v"))
+
+	// Reject unsupported keywords.
+	if specifier == "min-required" {
+		return fmt.Errorf("%q is not a valid uninstall target — "+
+			"resolve it first with tfenv resolve-version", specifier)
+	}
+	if specifier == "latest-allowed" {
+		return fmt.Errorf("%q is not a valid uninstall target — "+
+			"resolve it first with tfenv resolve-version", specifier)
+	}
+
+	// Resolve keywords against locally installed versions.
+	version, err := resolveLocalVersion(specifier, cfg)
+	if err != nil {
+		return err
+	}
+
+	// Path traversal protection.
+	if err := validateVersion(version); err != nil {
+		return err
+	}
+
+	// Verify the version is installed.
+	versionDir := filepath.Join(cfg.ConfigDir, "versions", version)
+	binaryPath := filepath.Join(versionDir, "terraform")
+
+	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
+		return fmt.Errorf("Terraform v%s is not installed", version)
+	} else if err != nil {
+		return fmt.Errorf("checking installation of v%s: %w", version, err)
+	}
+
+	// Remove the version directory.
+	if err := os.RemoveAll(versionDir); err != nil {
+		return fmt.Errorf("removing version directory %s: %w", versionDir, err)
+	}
+
+	fmt.Fprintf(os.Stdout, "Terraform v%s is successfully uninstalled\n", version)
+	return nil
+}
+
+// resolveLocalVersion resolves a version specifier against locally
+// installed versions. For "latest" and "latest:<regex>" it searches
+// the local installation directory. For exact versions, it returns
+// the specifier as-is.
+func resolveLocalVersion(specifier string, cfg *config.Config) (string, error) {
+	switch {
+	case specifier == "latest":
+		return resolveLatestLocal("", cfg)
+
+	case strings.HasPrefix(specifier, "latest:"):
+		pattern := strings.TrimPrefix(specifier, "latest:")
+		return resolveLatestLocal(pattern, cfg)
+
+	default:
+		return specifier, nil
+	}
+}
+
+// resolveLatestLocal finds the newest locally installed version,
+// optionally filtered by a regex pattern. An empty pattern matches all
+// stable versions.
+func resolveLatestLocal(pattern string, cfg *config.Config) (string, error) {
+	localVersions, err := list.ListLocal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("listing local versions: %w", err)
+	}
+
+	if len(localVersions) == 0 {
+		return "", fmt.Errorf("no versions installed")
+	}
+
+	if pattern == "" {
+		// "latest" — use resolve engine for consistency.
+		resolved, err := resolve.ResolveVersion("latest", localVersions, "local", cfg)
+		if err != nil {
+			return "", fmt.Errorf("resolving latest local version: %w", err)
+		}
+		return resolved.Version, nil
+	}
+
+	// "latest:<regex>" — filter locally and pick newest.
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", fmt.Errorf("invalid regex %q: %w", pattern, err)
+	}
+
+	var matched []string
+	for _, v := range localVersions {
+		if re.MatchString(v) {
+			matched = append(matched, v)
+		}
+	}
+
+	if len(matched) == 0 {
+		return "", fmt.Errorf("no installed version matches regex %q", pattern)
+	}
+
+	resolved, err := resolve.ResolveVersion("latest", matched, "local", cfg)
+	if err != nil {
+		return "", fmt.Errorf("resolving latest from matched versions: %w", err)
+	}
+	return resolved.Version, nil
+}
+
+// validateVersion rejects version strings that could cause path traversal.
+func validateVersion(version string) error {
+	if strings.Contains(version, "/") ||
+		strings.Contains(version, "\\") ||
+		strings.Contains(version, "..") ||
+		strings.ContainsRune(version, 0) {
+		return fmt.Errorf("invalid version string: %q", version)
+	}
+	return nil
+}

--- a/go/internal/uninstall/uninstall_test.go
+++ b/go/internal/uninstall/uninstall_test.go
@@ -1,0 +1,290 @@
+package uninstall
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/tfutils/tfenv/go/internal/config"
+)
+
+// setupTestVersions creates a temporary config directory with fake
+// installed versions. Each version gets a versions/<ver>/terraform file.
+// Returns the config and a cleanup function.
+func setupTestVersions(t *testing.T, versions ...string) *config.Config {
+	t.Helper()
+
+	configDir := t.TempDir()
+
+	for _, v := range versions {
+		versionDir := filepath.Join(configDir, "versions", v)
+		if err := os.MkdirAll(versionDir, 0o755); err != nil {
+			t.Fatalf("creating version dir %s: %v", v, err)
+		}
+		binaryPath := filepath.Join(versionDir, "terraform")
+		if err := os.WriteFile(binaryPath, []byte("fake-binary"), 0o755); err != nil {
+			t.Fatalf("creating fake binary for %s: %v", v, err)
+		}
+	}
+
+	return &config.Config{
+		ConfigDir: configDir,
+		Remote:    "https://releases.hashicorp.com",
+	}
+}
+
+func TestUninstallSingleVersion(t *testing.T) {
+	cfg := setupTestVersions(t, "1.5.0")
+
+	err := uninstallSingle("1.5.0", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	versionDir := filepath.Join(cfg.ConfigDir, "versions", "1.5.0")
+	if _, err := os.Stat(versionDir); !os.IsNotExist(err) {
+		t.Errorf("version directory still exists after uninstall")
+	}
+}
+
+func TestUninstallMultipleVersions(t *testing.T) {
+	cfg := setupTestVersions(t, "1.4.0", "1.5.0", "1.6.0")
+
+	for _, v := range []string{"1.4.0", "1.6.0"} {
+		if err := uninstallSingle(v, cfg); err != nil {
+			t.Fatalf("unexpected error uninstalling %s: %v", v, err)
+		}
+	}
+
+	// 1.4.0 and 1.6.0 should be gone.
+	for _, v := range []string{"1.4.0", "1.6.0"} {
+		versionDir := filepath.Join(cfg.ConfigDir, "versions", v)
+		if _, err := os.Stat(versionDir); !os.IsNotExist(err) {
+			t.Errorf("version %s directory still exists", v)
+		}
+	}
+
+	// 1.5.0 should still be there.
+	versionDir := filepath.Join(cfg.ConfigDir, "versions", "1.5.0")
+	if _, err := os.Stat(versionDir); err != nil {
+		t.Errorf("version 1.5.0 should still exist: %v", err)
+	}
+}
+
+func TestUninstallLatestResolvesFromLocal(t *testing.T) {
+	cfg := setupTestVersions(t, "1.3.0", "1.4.0", "1.5.0")
+
+	version, err := resolveLocalVersion("latest", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != "1.5.0" {
+		t.Errorf("expected latest to resolve to 1.5.0, got %s", version)
+	}
+}
+
+func TestUninstallLatestRegexResolvesFromLocal(t *testing.T) {
+	cfg := setupTestVersions(t, "1.3.0", "1.4.0", "1.4.5", "1.5.0")
+
+	version, err := resolveLocalVersion("latest:^1\\.4", cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if version != "1.4.5" {
+		t.Errorf("expected latest:^1\\.4 to resolve to 1.4.5, got %s", version)
+	}
+}
+
+func TestUninstallNoArgsReadsVersionFile(t *testing.T) {
+	cfg := setupTestVersions(t, "1.5.0")
+
+	// Write a .terraform-version file in a temp directory.
+	tempDir := t.TempDir()
+	versionFile := filepath.Join(tempDir, ".terraform-version")
+	if err := os.WriteFile(versionFile, []byte("1.5.0\n"), 0o644); err != nil {
+		t.Fatalf("writing version file: %v", err)
+	}
+
+	// Set Dir so the version file walker finds it.
+	cfg.Dir = tempDir
+
+	versions, err := collectVersions(nil, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(versions) != 1 || versions[0] != "1.5.0" {
+		t.Errorf("expected [1.5.0], got %v", versions)
+	}
+}
+
+func TestUninstallMinRequiredRejected(t *testing.T) {
+	cfg := setupTestVersions(t, "1.5.0")
+
+	err := uninstallSingle("min-required", cfg)
+	if err == nil {
+		t.Fatal("expected error for min-required")
+	}
+	if got := err.Error(); !contains(got, "not a valid uninstall target") {
+		t.Errorf("unexpected error message: %s", got)
+	}
+}
+
+func TestUninstallLatestAllowedRejected(t *testing.T) {
+	cfg := setupTestVersions(t, "1.5.0")
+
+	err := uninstallSingle("latest-allowed", cfg)
+	if err == nil {
+		t.Fatal("expected error for latest-allowed")
+	}
+	if got := err.Error(); !contains(got, "not a valid uninstall target") {
+		t.Errorf("unexpected error message: %s", got)
+	}
+}
+
+func TestUninstallVersionNotInstalled(t *testing.T) {
+	cfg := setupTestVersions(t, "1.5.0")
+
+	err := uninstallSingle("1.9.9", cfg)
+	if err == nil {
+		t.Fatal("expected error for version not installed")
+	}
+	if got := err.Error(); !contains(got, "not installed") {
+		t.Errorf("unexpected error message: %s", got)
+	}
+}
+
+func TestUninstallPathTraversalRejected(t *testing.T) {
+	cfg := setupTestVersions(t, "1.5.0")
+
+	cases := []struct {
+		name    string
+		version string
+	}{
+		{"dot-dot", "1.5.0/../.."},
+		{"forward-slash", "1.5.0/../../etc"},
+		{"backslash", "1.5.0\\.."},
+		{"null-byte", "1.5.0\x00"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := uninstallSingle(tc.version, cfg)
+			if err == nil {
+				t.Fatal("expected error for path traversal")
+			}
+			if got := err.Error(); !contains(got, "invalid version string") {
+				t.Errorf("unexpected error message: %s", got)
+			}
+		})
+	}
+}
+
+func TestUninstallContinueOnPartialFailure(t *testing.T) {
+	cfg := setupTestVersions(t, "1.4.0", "1.5.0")
+
+	// Uninstall one that exists and one that doesn't.
+	specifiers := []string{"1.4.0", "1.9.9", "1.5.0"}
+
+	failures := 0
+	for _, s := range specifiers {
+		if err := uninstallSingle(s, cfg); err != nil {
+			failures++
+		}
+	}
+
+	// 1.9.9 should have failed.
+	if failures != 1 {
+		t.Errorf("expected 1 failure, got %d", failures)
+	}
+
+	// 1.4.0 and 1.5.0 should be gone.
+	for _, v := range []string{"1.4.0", "1.5.0"} {
+		versionDir := filepath.Join(cfg.ConfigDir, "versions", v)
+		if _, err := os.Stat(versionDir); !os.IsNotExist(err) {
+			t.Errorf("version %s directory still exists", v)
+		}
+	}
+}
+
+func TestUninstallPostCleanupEmptyVersionsDir(t *testing.T) {
+	cfg := setupTestVersions(t, "1.5.0")
+
+	// Uninstall the only version.
+	if err := uninstallSingle("1.5.0", cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	versionsDir := filepath.Join(cfg.ConfigDir, "versions")
+
+	// Post-cleanup: remove if empty.
+	_ = os.Remove(versionsDir)
+
+	if _, err := os.Stat(versionsDir); !os.IsNotExist(err) {
+		t.Errorf("empty versions directory should be removed after cleanup")
+	}
+}
+
+func TestValidateVersion(t *testing.T) {
+	valid := []string{"1.5.0", "1.5.0-alpha1", "1.5.0-rc.1", "0.12.31"}
+	for _, v := range valid {
+		if err := validateVersion(v); err != nil {
+			t.Errorf("validateVersion(%q) unexpected error: %v", v, err)
+		}
+	}
+
+	invalid := []string{
+		"../etc/passwd",
+		"1.5.0/../../etc",
+		"1.5.0\\..\\windows",
+		"1.5.0\x00",
+	}
+	for _, v := range invalid {
+		if err := validateVersion(v); err == nil {
+			t.Errorf("validateVersion(%q) expected error, got nil", v)
+		}
+	}
+}
+
+func TestCollectVersionsFromArgs(t *testing.T) {
+	cfg := setupTestVersions(t)
+
+	versions, err := collectVersions([]string{"1.4.0", "1.5.0"}, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Fatalf("expected 2 versions, got %d", len(versions))
+	}
+	if versions[0] != "1.4.0" || versions[1] != "1.5.0" {
+		t.Errorf("expected [1.4.0 1.5.0], got %v", versions)
+	}
+}
+
+func TestCollectVersionsFromEnvVar(t *testing.T) {
+	cfg := setupTestVersions(t)
+	cfg.TerraformVersion = "1.6.0"
+
+	versions, err := collectVersions(nil, cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(versions) != 1 || versions[0] != "1.6.0" {
+		t.Errorf("expected [1.6.0], got %v", versions)
+	}
+}
+
+// contains is a helper to check substring presence.
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) &&
+		(s == substr || len(s) > 0 && containsSubstr(s, substr))
+}
+
+func containsSubstr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Implements #500 — `tfenv uninstall` for the Go edition with multi-version support, keyword resolution (`latest`, `latest:<regex>`), version-file fallback, and path traversal protection.

## Changes

- `go/internal/uninstall/uninstall.go` — command handler + registration
- `go/internal/uninstall/uninstall_test.go` — 14 unit tests covering all acceptance criteria
- `go/cmd/tfenv/main.go` — blank import for registration

## Acceptance Criteria

- [x] Single version uninstall (`tfenv uninstall 1.5.0`)
- [x] Multi-version uninstall (`tfenv uninstall 1.5.0 1.4.0`)
- [x] `latest` resolves from locally installed versions
- [x] `latest:<regex>` resolves from locally installed versions
- [x] No args reads from `.terraform-version` / `TFENV_TERRAFORM_VERSION`
- [x] `min-required` / `latest-allowed` rejected with clear error
- [x] Version not installed produces clear error
- [x] Path traversal protection (rejects `..`, `/`, `\`, null bytes)
- [x] Continue on partial failure, exit non-zero if any failed
- [x] Post-cleanup of empty versions directory
- [x] `go vet ./...` clean
- [x] `go test ./... -v` all pass
- [x] `go test -race ./...` clean

Closes #500