### PR TITLE
[STACKED] feat: pin command

### DIFF
--- a/go/cmd/tfenv/main.go
+++ b/go/cmd/tfenv/main.go
@@ -18,6 +18,7 @@ import (
 	// Register subcommands via init().
 	_ "github.com/tfutils/tfenv/go/internal/install"
 	_ "github.com/tfutils/tfenv/go/internal/list"
+	_ "github.com/tfutils/tfenv/go/internal/pin"
 	_ "github.com/tfutils/tfenv/go/internal/uninstall"
 	_ "github.com/tfutils/tfenv/go/internal/use"
 )

--- a/go/internal/pin/pin.go
+++ b/go/internal/pin/pin.go
@@ -1,0 +1,120 @@
+// Package pin implements the tfenv pin command — writing the currently
+// resolved version to .terraform-version in the current directory.
+package pin
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/tfutils/tfenv/go/internal/cli"
+	"github.com/tfutils/tfenv/go/internal/config"
+	"github.com/tfutils/tfenv/go/internal/list"
+	"github.com/tfutils/tfenv/go/internal/logging"
+	"github.com/tfutils/tfenv/go/internal/resolve"
+)
+
+func init() {
+	cli.Register("pin", "Write the current active version to .terraform-version", Run)
+}
+
+// Run implements the tfenv pin command.
+// It accepts no arguments. Resolves the current version from the version
+// file chain, resolves keywords to a concrete installed version, and writes
+// it to .terraform-version in the current directory.
+//
+// Returns 0 on success, 1 on error.
+func Run(args []string) int {
+	if len(args) > 0 {
+		logging.Error("usage: tfenv pin")
+		return 1
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		logging.Error("failed to load configuration", "err", err)
+		return 1
+	}
+
+	// Verify versions directory exists and is accessible.
+	versionsDir := filepath.Join(cfg.ConfigDir, "versions")
+	if _, err := os.Stat(versionsDir); err != nil {
+		if os.IsNotExist(err) {
+			logging.Error("No versions available. Please install one with: tfenv install")
+			return 1
+		}
+		logging.Error("failed to access versions directory", "err", err)
+		return 1
+	}
+
+	// Resolve current version from the version file chain.
+	result, err := resolve.ResolveVersionFile(cfg)
+	if err != nil {
+		logging.Error("failed to resolve current version", "err", err)
+		return 1
+	}
+
+	logging.Debug("version file resolved", "version", result.Version, "source", result.Source)
+
+	// Resolve keywords (latest, latest:<regex>, etc.) to a concrete
+	// installed version.
+	version, err := resolveConcreteVersion(result.Version, cfg)
+	if err != nil {
+		logging.Error("failed to resolve concrete version", "err", err)
+		return 1
+	}
+
+	// Write .terraform-version in the current directory.
+	cwd, err := os.Getwd()
+	if err != nil {
+		logging.Error("failed to determine working directory", "err", err)
+		return 1
+	}
+
+	path := filepath.Join(cwd, ".terraform-version")
+	if err := os.WriteFile(path, []byte(version+"\n"), 0o644); err != nil {
+		logging.Error("failed to write .terraform-version", "err", err)
+		return 1
+	}
+
+	logging.Info(fmt.Sprintf("Pinned version by writing %q to %s", version, path))
+	return 0
+}
+
+// resolveConcreteVersion resolves a version specifier to a concrete version
+// string using locally installed versions. If the specifier is already an
+// exact version, it is returned as-is.
+func resolveConcreteVersion(specifier string, cfg *config.Config) (string, error) {
+	// Exact versions pass through directly.
+	if isExactVersion(specifier) {
+		return specifier, nil
+	}
+
+	// Keyword specifiers need resolution against local versions.
+	localVersions, err := list.ListLocal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("listing local versions: %w", err)
+	}
+
+	if len(localVersions) == 0 {
+		return "", fmt.Errorf(
+			"no installed versions available to resolve %q. Please install one with: tfenv install",
+			specifier)
+	}
+
+	resolved, err := resolve.ResolveVersion(specifier, localVersions, "local", cfg)
+	if err != nil {
+		return "", fmt.Errorf("resolving %q against local versions: %w", specifier, err)
+	}
+
+	return resolved.Version, nil
+}
+
+// isExactVersion returns true if the specifier looks like a concrete version
+// number (starts with a digit).
+func isExactVersion(specifier string) bool {
+	if len(specifier) == 0 {
+		return false
+	}
+	return specifier[0] >= '0' && specifier[0] <= '9'
+}

--- a/go/internal/pin/pin_test.go
+++ b/go/internal/pin/pin_test.go
@@ -1,0 +1,253 @@
+package pin
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/tfutils/tfenv/go/internal/config"
+)
+
+// setupTestDir creates a temporary config directory with the given installed
+// versions. Each version gets a directory with a fake terraform binary.
+func setupTestDir(t *testing.T, versions ...string) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	versionsDir := filepath.Join(dir, "versions")
+	if err := os.MkdirAll(versionsDir, 0o755); err != nil {
+		t.Fatalf("creating versions dir: %v", err)
+	}
+
+	for _, v := range versions {
+		vDir := filepath.Join(versionsDir, v)
+		if err := os.MkdirAll(vDir, 0o755); err != nil {
+			t.Fatalf("creating version dir %s: %v", v, err)
+		}
+
+		binaryName := "terraform"
+		if runtime.GOOS == "windows" {
+			binaryName = "terraform.exe"
+		}
+		binaryPath := filepath.Join(vDir, binaryName)
+		if err := os.WriteFile(binaryPath, []byte("#!/bin/sh\necho fake"), 0o755); err != nil {
+			t.Fatalf("writing fake binary %s: %v", binaryPath, err)
+		}
+	}
+
+	return dir
+}
+
+// testConfig returns a Config pointing at the test directory.
+func testConfig(configDir string) *config.Config {
+	return &config.Config{
+		ConfigDir:   configDir,
+		AutoInstall: false,
+	}
+}
+
+func TestPinRejectsArguments(t *testing.T) {
+	exitCode := Run([]string{"1.5.0"})
+	if exitCode != 1 {
+		t.Errorf("expected exit code 1 for extra arguments, got %d", exitCode)
+	}
+}
+
+func TestPinErrorIfNoVersionsDirectory(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a regular file that blocks config.Load from creating the
+	// config directory tree (MkdirAll fails when a path component is a file).
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("block"), 0o644); err != nil {
+		t.Fatalf("creating blocker file: %v", err)
+	}
+	t.Setenv("TFENV_CONFIG_DIR", filepath.Join(blocker, "config"))
+
+	exitCode := Run(nil)
+	if exitCode != 1 {
+		t.Errorf("expected exit code 1 when config dir cannot be created, got %d", exitCode)
+	}
+}
+
+func TestPinErrorIfNoVersionResolvable(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0")
+
+	// No version file, no env var — resolution should fail.
+	t.Setenv("TFENV_CONFIG_DIR", dir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "")
+
+	// Change to a temp directory with no .terraform-version.
+	workDir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getting cwd: %v", err)
+	}
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("chdir to %s: %v", workDir, err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	// Remove the default version file if it exists.
+	os.Remove(filepath.Join(dir, "version"))
+
+	exitCode := Run(nil)
+	if exitCode != 1 {
+		t.Errorf("expected exit code 1 when no version resolvable, got %d", exitCode)
+	}
+}
+
+func TestPinWritesCorrectContent(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0", "1.6.0")
+
+	t.Setenv("TFENV_CONFIG_DIR", dir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "1.5.0")
+
+	// Work in a temporary directory.
+	workDir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getting cwd: %v", err)
+	}
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("chdir to %s: %v", workDir, err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	exitCode := Run(nil)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	versionFile := filepath.Join(workDir, ".terraform-version")
+	data, err := os.ReadFile(versionFile)
+	if err != nil {
+		t.Fatalf("reading .terraform-version: %v", err)
+	}
+
+	got := strings.TrimSpace(string(data))
+	if got != "1.5.0" {
+		t.Errorf("expected .terraform-version to contain %q, got %q", "1.5.0", got)
+	}
+}
+
+func TestPinOverwritesExistingFile(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0", "1.6.0")
+
+	t.Setenv("TFENV_CONFIG_DIR", dir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "1.6.0")
+
+	// Work in a temporary directory with an existing .terraform-version.
+	workDir := t.TempDir()
+	existingFile := filepath.Join(workDir, ".terraform-version")
+	if err := os.WriteFile(existingFile, []byte("1.5.0\n"), 0o644); err != nil {
+		t.Fatalf("writing existing file: %v", err)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getting cwd: %v", err)
+	}
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("chdir to %s: %v", workDir, err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	exitCode := Run(nil)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	data, err := os.ReadFile(existingFile)
+	if err != nil {
+		t.Fatalf("reading .terraform-version: %v", err)
+	}
+
+	got := strings.TrimSpace(string(data))
+	if got != "1.6.0" {
+		t.Errorf("expected .terraform-version to contain %q, got %q", "1.6.0", got)
+	}
+}
+
+func TestPinResolvesLatestKeyword(t *testing.T) {
+	dir := setupTestDir(t, "1.4.0", "1.5.0", "1.6.0")
+
+	t.Setenv("TFENV_CONFIG_DIR", dir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "latest")
+
+	workDir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getting cwd: %v", err)
+	}
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatalf("chdir to %s: %v", workDir, err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	exitCode := Run(nil)
+	if exitCode != 0 {
+		t.Fatalf("expected exit code 0, got %d", exitCode)
+	}
+
+	data, err := os.ReadFile(filepath.Join(workDir, ".terraform-version"))
+	if err != nil {
+		t.Fatalf("reading .terraform-version: %v", err)
+	}
+
+	got := strings.TrimSpace(string(data))
+	if got != "1.6.0" {
+		t.Errorf("expected .terraform-version to contain %q, got %q", "1.6.0", got)
+	}
+}
+
+func TestResolveConcreteVersionExact(t *testing.T) {
+	dir := setupTestDir(t, "1.5.0")
+	cfg := testConfig(dir)
+
+	got, err := resolveConcreteVersion("1.5.0", cfg)
+	if err != nil {
+		t.Fatalf("resolveConcreteVersion(1.5.0): %v", err)
+	}
+	if got != "1.5.0" {
+		t.Errorf("expected 1.5.0, got %s", got)
+	}
+}
+
+func TestResolveConcreteVersionLatest(t *testing.T) {
+	dir := setupTestDir(t, "1.4.0", "1.5.0", "1.6.0")
+	cfg := testConfig(dir)
+
+	got, err := resolveConcreteVersion("latest", cfg)
+	if err != nil {
+		t.Fatalf("resolveConcreteVersion(latest): %v", err)
+	}
+	if got != "1.6.0" {
+		t.Errorf("expected 1.6.0, got %s", got)
+	}
+}
+
+func TestResolveConcreteVersionLatestRegex(t *testing.T) {
+	dir := setupTestDir(t, "1.4.0", "1.5.1", "1.5.3", "1.6.0")
+	cfg := testConfig(dir)
+
+	got, err := resolveConcreteVersion("latest:^1\\.5", cfg)
+	if err != nil {
+		t.Fatalf("resolveConcreteVersion(latest:^1.5): %v", err)
+	}
+	if got != "1.5.3" {
+		t.Errorf("expected 1.5.3, got %s", got)
+	}
+}
+
+func TestResolveConcreteVersionNoLocalVersions(t *testing.T) {
+	dir := setupTestDir(t) // No versions installed.
+	cfg := testConfig(dir)
+
+	_, err := resolveConcreteVersion("latest", cfg)
+	if err == nil {
+		t.Fatal("expected error for latest with no installed versions")
+	}
+}


### PR DESCRIPTION
Implements #501 — `tfenv pin` command for the Go edition.

Resolves the current Terraform version from the version file chain, resolves keywords (`latest`, `latest:<regex>`) to concrete installed versions, and writes the result to `.terraform-version` in the current directory.

## Changes

- **`go/internal/pin/pin.go`** — `Run` handler registered via `init()`, resolves version, writes file
- **`go/internal/pin/pin_test.go`** — 10 unit tests covering all acceptance criteria
- **`go/cmd/tfenv/main.go`** — blank import to register the pin subcommand

## Acceptance Criteria

- [x] Creates `.terraform-version` with correct content
- [x] Rejects arguments
- [x] Error if no versions directory / config unloadable
- [x] Error if no version resolvable
- [x] Overwrites existing file
- [x] Resolves keyword specifiers (latest, latest:regex) to concrete versions

## Verification

```
go vet ./...          # clean
go test ./... -v      # 12/12 packages pass
go test -race ./...   # clean
tfenv-go help         # shows pin command
```

Closes #501