### PR TITLE
feat: exec/terraform shim with auto-install and init command

### DIFF
--- a/go/cmd/tfenv/main.go
+++ b/go/cmd/tfenv/main.go
@@ -11,6 +11,8 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 
 	"github.com/tfutils/tfenv/go/internal/cli"
 	"github.com/tfutils/tfenv/go/internal/shim"
@@ -29,6 +31,11 @@ var version = "dev"
 
 func main() {
 	basename := filepath.Base(os.Args[0])
+
+	// Strip .exe suffix on Windows for multi-call matching.
+	if runtime.GOOS == "windows" {
+		basename = strings.TrimSuffix(basename, ".exe")
+	}
 
 	switch basename {
 	case "terraform":

--- a/go/internal/shim/exec_unix.go
+++ b/go/internal/shim/exec_unix.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package shim
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// execTerraform replaces the current process with the real terraform binary
+// using syscall.Exec. On success this function never returns — the process
+// image is replaced entirely. This avoids child-process overhead and ensures
+// terraform receives signals (SIGINT, SIGTERM) directly.
+func execTerraform(binaryPath string, args []string) int {
+	argv := append([]string{binaryPath}, args...)
+	env := os.Environ()
+
+	if err := syscall.Exec(binaryPath, argv, env); err != nil {
+		fmt.Fprintf(os.Stderr, "tfenv: exec %s: %v\n", binaryPath, err)
+		return 1
+	}
+
+	// Unreachable on success — process is replaced.
+	return 0
+}

--- a/go/internal/shim/exec_windows.go
+++ b/go/internal/shim/exec_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package shim
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// execTerraform runs the real terraform binary as a child process on Windows,
+// piping stdin/stdout/stderr through. Windows does not support syscall.Exec
+// (process image replacement), so we use os/exec and forward the exit code.
+func execTerraform(binaryPath string, args []string) int {
+	cmd := exec.Command(binaryPath, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Run(); err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return exitErr.ExitCode()
+		}
+		fmt.Fprintf(os.Stderr,
+			"tfenv: exec %s: %v\n", binaryPath, err)
+		return 1
+	}
+
+	return 0
+}

--- a/go/internal/shim/init_command.go
+++ b/go/internal/shim/init_command.go
@@ -1,0 +1,115 @@
+package shim
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"github.com/tfutils/tfenv/go/internal/cli"
+	"github.com/tfutils/tfenv/go/internal/logging"
+)
+
+func init() {
+	cli.Register("init",
+		"Create terraform hardlink/copy next to tfenv binary",
+		RunInit)
+}
+
+// RunInit creates a "terraform" hardlink (or copy) next to the running
+// tfenv binary, enabling the multi-call binary to intercept terraform
+// invocations. It is idempotent — re-running when the link already
+// exists and points to the same file is a successful no-op.
+func RunInit(args []string) int {
+	exe, err := os.Executable()
+	if err != nil {
+		logging.Error("failed to determine executable path",
+			"err", err)
+		return 1
+	}
+
+	exe, err = filepath.EvalSymlinks(exe)
+	if err != nil {
+		logging.Error("failed to resolve symlinks",
+			"path", exe, "err", err)
+		return 1
+	}
+
+	dir := filepath.Dir(exe)
+	terraformName := "terraform"
+	if runtime.GOOS == "windows" {
+		terraformName = "terraform.exe"
+	}
+	terraformPath := filepath.Join(dir, terraformName)
+
+	// Idempotent: if terraform already exists and is the same file,
+	// nothing to do.
+	if isSameFile(exe, terraformPath) {
+		fmt.Fprintf(os.Stderr, "Already exists: %s\n", terraformPath)
+		return 0
+	}
+
+	// Remove a stale terraform binary if present (might be from an
+	// older version or a different binary entirely).
+	if _, statErr := os.Stat(terraformPath); statErr == nil {
+		if removeErr := os.Remove(terraformPath); removeErr != nil {
+			logging.Error("failed to remove existing terraform",
+				"path", terraformPath, "err", removeErr)
+			return 1
+		}
+	}
+
+	// Try hardlink first — same inode, no extra disk space.
+	if linkErr := os.Link(exe, terraformPath); linkErr != nil {
+		logging.Debug("hardlink failed, falling back to copy",
+			"err", linkErr)
+
+		if copyErr := copyFile(exe, terraformPath); copyErr != nil {
+			logging.Error("failed to create terraform binary",
+				"path", terraformPath, "err", copyErr)
+			return 1
+		}
+	}
+
+	fmt.Fprintf(os.Stderr, "Created %s\n", terraformPath)
+	return 0
+}
+
+// isSameFile checks whether two paths refer to the same underlying file
+// (same device and inode on Unix).
+func isSameFile(a, b string) bool {
+	infoA, errA := os.Stat(a)
+	infoB, errB := os.Stat(b)
+	if errA != nil || errB != nil {
+		return false
+	}
+	return os.SameFile(infoA, infoB)
+}
+
+// copyFile copies src to dst, preserving the source's permission bits.
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return fmt.Errorf("opening source %s: %w", src, err)
+	}
+	defer in.Close()
+
+	info, err := in.Stat()
+	if err != nil {
+		return fmt.Errorf("stat source %s: %w", src, err)
+	}
+
+	out, err := os.OpenFile(
+		dst, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, info.Mode())
+	if err != nil {
+		return fmt.Errorf("creating destination %s: %w", dst, err)
+	}
+	defer out.Close()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return fmt.Errorf("copying %s to %s: %w", src, dst, err)
+	}
+
+	return nil
+}

--- a/go/internal/shim/shim.go
+++ b/go/internal/shim/shim.go
@@ -1,15 +1,161 @@
 // Package shim implements the Terraform shim, intercepting calls to the
-// terraform binary and delegating to the correct installed version.
+// terraform binary, resolving the correct installed version, optionally
+// auto-installing missing versions, and exec'ing the real binary.
+//
+// All shim output goes to stderr — stdout is reserved exclusively for
+// terraform's own output (critical for terraform output, JSON mode, etc.).
 package shim
 
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/tfutils/tfenv/go/internal/config"
+	"github.com/tfutils/tfenv/go/internal/install"
+	"github.com/tfutils/tfenv/go/internal/list"
+	"github.com/tfutils/tfenv/go/internal/logging"
+	"github.com/tfutils/tfenv/go/internal/resolve"
 )
 
 // Run is the entry point for the terraform shim.
-// It is invoked when the binary is called as "terraform" via symlink.
+// It is invoked when the binary is called as "terraform" via hardlink
+// or copy (multi-call binary pattern).
 func Run(args []string) int {
-	fmt.Fprintf(os.Stderr, "terraform shim not yet implemented\n")
-	return 1
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tfenv: failed to load config: %v\n", err)
+		return 1
+	}
+
+	// Detect -chdir=<dir> and set cfg.Dir so version file resolution
+	// starts from the terraform working directory, not the shell cwd.
+	if dir := extractChdir(args); dir != "" {
+		cfg.Dir = dir
+	}
+
+	// Resolve the version specifier from the version file chain.
+	result, err := resolve.ResolveVersionFile(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tfenv: %v\n", err)
+		return 1
+	}
+
+	logging.Debug("version file resolved",
+		"version", result.Version, "source", result.Source)
+
+	version := result.Version
+
+	// If the specifier is a keyword (latest, latest:<regex>, etc.),
+	// resolve it against locally installed versions first.
+	if !isExactVersion(version) {
+		version, err = resolveKeyword(version, result.Source, cfg)
+		if err != nil {
+			// No local match — auto-install or error.
+			if !cfg.AutoInstall {
+				fmt.Fprintf(os.Stderr,
+					"tfenv: no installed version matches %q "+
+						"and auto-install is disabled\n",
+					result.Version)
+				return 1
+			}
+
+			logging.Info("No local version matches, auto-installing",
+				"specifier", result.Version)
+
+			if install.Run([]string{result.Version}) != 0 {
+				return 1
+			}
+
+			// Re-resolve against local versions after install.
+			version, err = resolveKeyword(
+				result.Version, result.Source, cfg)
+			if err != nil {
+				fmt.Fprintf(os.Stderr,
+					"tfenv: failed to resolve version "+
+						"after install: %v\n", err)
+				return 1
+			}
+		}
+	}
+
+	// Determine the path to the real terraform binary.
+	binaryPath := terraformBinaryPath(cfg.ConfigDir, version)
+
+	// If the binary doesn't exist, auto-install or error.
+	if _, statErr := os.Stat(binaryPath); os.IsNotExist(statErr) {
+		if cfg.AutoInstall {
+			logging.Info("Auto-installing Terraform",
+				"version", version)
+			if install.Run([]string{version}) != 0 {
+				return 1
+			}
+		} else {
+			fmt.Fprintf(os.Stderr,
+				"Terraform v%s is not installed. "+
+					"Install it with: tfenv install %s\n",
+				version, version)
+			return 1
+		}
+	}
+
+	// Exec the real terraform binary, replacing this process on Unix.
+	logging.Debug("exec terraform", "path", binaryPath, "args", args)
+	return execTerraform(binaryPath, args)
+}
+
+// extractChdir scans terraform arguments for -chdir=<dir> and returns
+// the directory path. Returns "" if -chdir is not present.
+func extractChdir(args []string) string {
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-chdir=") {
+			return strings.TrimPrefix(arg, "-chdir=")
+		}
+	}
+	return ""
+}
+
+// isExactVersion returns true if the version string looks like a concrete
+// semver version (starts with a digit) rather than a keyword.
+func isExactVersion(version string) bool {
+	return len(version) > 0 && version[0] >= '0' && version[0] <= '9'
+}
+
+// resolveKeyword resolves a keyword specifier (latest, latest:<regex>,
+// latest-allowed, min-required) against locally installed versions.
+func resolveKeyword(
+	specifier string,
+	source string,
+	cfg *config.Config,
+) (string, error) {
+	locals, err := list.ListLocal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("listing local versions: %w", err)
+	}
+
+	if len(locals) == 0 {
+		return "", fmt.Errorf(
+			"no local versions installed for specifier %q",
+			specifier)
+	}
+
+	resolved, err := resolve.ResolveVersion(
+		specifier, locals, source, cfg)
+	if err != nil {
+		return "", err
+	}
+
+	return resolved.Version, nil
+}
+
+// terraformBinaryPath returns the full path to the terraform binary for
+// a given version within the config directory.
+func terraformBinaryPath(configDir, version string) string {
+	name := "terraform"
+	if runtime.GOOS == "windows" {
+		name = "terraform.exe"
+	}
+	return filepath.Join(configDir, "versions", version, name)
 }

--- a/go/internal/shim/shim_test.go
+++ b/go/internal/shim/shim_test.go
@@ -1,12 +1,457 @@
 package shim
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
-func TestRunReturnsOne(t *testing.T) {
+// --- extractChdir tests ---
+
+func TestExtractChdir_Present(t *testing.T) {
+	args := []string{"-chdir=/tmp/project", "plan"}
+	got := extractChdir(args)
+	if got != "/tmp/project" {
+		t.Errorf("extractChdir = %q, want %q", got, "/tmp/project")
+	}
+}
+
+func TestExtractChdir_NotPresent(t *testing.T) {
+	args := []string{"plan", "-out=tfplan"}
+	got := extractChdir(args)
+	if got != "" {
+		t.Errorf("extractChdir = %q, want empty", got)
+	}
+}
+
+func TestExtractChdir_Empty(t *testing.T) {
+	got := extractChdir(nil)
+	if got != "" {
+		t.Errorf("extractChdir(nil) = %q, want empty", got)
+	}
+}
+
+func TestExtractChdir_MultipleArgs(t *testing.T) {
+	args := []string{"-input=false", "-chdir=mydir", "-auto-approve"}
+	got := extractChdir(args)
+	if got != "mydir" {
+		t.Errorf("extractChdir = %q, want %q", got, "mydir")
+	}
+}
+
+func TestExtractChdir_RelativePath(t *testing.T) {
+	args := []string{"-chdir=../other"}
+	got := extractChdir(args)
+	if got != "../other" {
+		t.Errorf("extractChdir = %q, want %q", got, "../other")
+	}
+}
+
+// --- isExactVersion tests ---
+
+func TestIsExactVersion_Exact(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"1.5.0", true},
+		{"0.12.31", true},
+		{"1.5.0-rc1", true},
+		{"latest", false},
+		{"latest:^1.5", false},
+		{"latest-allowed", false},
+		{"min-required", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		got := isExactVersion(tt.input)
+		if got != tt.want {
+			t.Errorf(
+				"isExactVersion(%q) = %v, want %v",
+				tt.input, got, tt.want)
+		}
+	}
+}
+
+// --- terraformBinaryPath tests ---
+
+func TestTerraformBinaryPath(t *testing.T) {
+	got := terraformBinaryPath("/home/user/.tfenv", "1.5.0")
+	want := filepath.Join(
+		"/home/user/.tfenv", "versions", "1.5.0", "terraform")
+	if runtime.GOOS == "windows" {
+		want = filepath.Join(
+			"/home/user/.tfenv", "versions", "1.5.0",
+			"terraform.exe")
+	}
+	if got != want {
+		t.Errorf(
+			"terraformBinaryPath = %q, want %q", got, want)
+	}
+}
+
+// --- Run integration-style tests ---
+
+func TestRun_NoVersionFile(t *testing.T) {
+	// Set up isolated config dir with no version file.
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	workDir := filepath.Join(tmpDir, "work")
+
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Point config and working directory to isolated locations.
+	t.Setenv("TFENV_CONFIG_DIR", configDir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "")
+	t.Setenv("TFENV_AUTO_INSTALL", "false")
+	t.Setenv("HOME", tmpDir)
+
+	// Change to workDir so the version file walk doesn't find
+	// anything from the real filesystem.
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
 	exit := Run([]string{"version"})
 	if exit != 1 {
-		t.Errorf("expected exit code 1 (stub not implemented), got %d", exit)
+		t.Errorf("expected exit 1 with no version file, got %d", exit)
+	}
+}
+
+func TestRun_ExactVersion_NotInstalled_NoAutoInstall(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	workDir := filepath.Join(tmpDir, "work")
+
+	if err := os.MkdirAll(
+		filepath.Join(configDir, "versions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TFENV_CONFIG_DIR", configDir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "1.5.0")
+	t.Setenv("TFENV_AUTO_INSTALL", "false")
+
+	exit := Run([]string{"version"})
+	if exit != 1 {
+		t.Errorf(
+			"expected exit 1 for missing version without "+
+				"auto-install, got %d", exit)
+	}
+}
+
+func TestRun_ChdirSetsConfigDir(t *testing.T) {
+	// Create a directory structure with a .terraform-version file
+	// in the -chdir target.
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	chdirTarget := filepath.Join(tmpDir, "project")
+
+	if err := os.MkdirAll(
+		filepath.Join(configDir, "versions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(chdirTarget, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a .terraform-version in the chdir target.
+	versionFile := filepath.Join(
+		chdirTarget, ".terraform-version")
+	if err := os.WriteFile(
+		versionFile, []byte("1.6.0\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TFENV_CONFIG_DIR", configDir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "")
+	t.Setenv("TFENV_AUTO_INSTALL", "false")
+	t.Setenv("HOME", tmpDir)
+
+	// Working directory has no version file.
+	workDir := filepath.Join(tmpDir, "empty")
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Run with -chdir pointing to the project dir. It should find
+	// v1.6.0 from the version file, then fail because it's not
+	// installed (auto-install off). The important thing is that it
+	// found the version file via -chdir, not the cwd.
+	exit := Run([]string{
+		"-chdir=" + chdirTarget, "plan"})
+	if exit != 1 {
+		t.Errorf(
+			"expected exit 1 (version not installed), got %d",
+			exit)
+	}
+}
+
+func TestRun_KeywordVersion_NoLocalVersions_NoAutoInstall(
+	t *testing.T,
+) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+
+	if err := os.MkdirAll(
+		filepath.Join(configDir, "versions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TFENV_CONFIG_DIR", configDir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "latest")
+	t.Setenv("TFENV_AUTO_INSTALL", "false")
+
+	exit := Run([]string{"version"})
+	if exit != 1 {
+		t.Errorf(
+			"expected exit 1 for keyword with no local "+
+				"versions, got %d", exit)
+	}
+}
+
+func TestRun_KeywordVersion_WithLocalVersions(t *testing.T) {
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+
+	// Create fake installed versions (just directories — the binary
+	// won't exist, so we'll get exit 1 at the exec step).
+	versions := []string{"1.4.0", "1.5.0", "1.5.7"}
+	for _, v := range versions {
+		vDir := filepath.Join(configDir, "versions", v)
+		if err := os.MkdirAll(vDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	t.Setenv("TFENV_CONFIG_DIR", configDir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "latest")
+	t.Setenv("TFENV_AUTO_INSTALL", "false")
+
+	// Should resolve "latest" to 1.5.7, then fail because there's
+	// no actual terraform binary. Exit code 1 is expected.
+	exit := Run([]string{"version"})
+	if exit != 1 {
+		t.Errorf(
+			"expected exit 1 (no terraform binary), got %d",
+			exit)
+	}
+}
+
+// --- isSameFile tests ---
+
+func TestIsSameFile_Same(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "a")
+	if err := os.WriteFile(src, []byte("hello"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(tmpDir, "b")
+	if err := os.Link(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isSameFile(src, dst) {
+		t.Error("isSameFile should return true for hardlinked files")
+	}
+}
+
+func TestIsSameFile_Different(t *testing.T) {
+	tmpDir := t.TempDir()
+	a := filepath.Join(tmpDir, "a")
+	b := filepath.Join(tmpDir, "b")
+	if err := os.WriteFile(a, []byte("one"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(b, []byte("two"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if isSameFile(a, b) {
+		t.Error(
+			"isSameFile should return false for different files")
+	}
+}
+
+func TestIsSameFile_Missing(t *testing.T) {
+	if isSameFile("/nonexistent/a", "/nonexistent/b") {
+		t.Error(
+			"isSameFile should return false for missing files")
+	}
+}
+
+// --- copyFile tests ---
+
+func TestCopyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "src")
+	content := []byte("#!/bin/sh\necho hello\n")
+	if err := os.WriteFile(src, content, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(tmpDir, "dst")
+	if err := copyFile(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(got) != string(content) {
+		t.Errorf("copied content = %q, want %q", got, content)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if info.Mode().Perm()&0o111 == 0 {
+		t.Error("copied file should be executable")
+	}
+}
+
+// --- RunInit tests ---
+
+func TestRunInit_CreatesHardlink(t *testing.T) {
+	// RunInit uses os.Executable() which we can't easily control
+	// in a unit test. Instead, test the helper functions and
+	// verify the init logic components work correctly.
+
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "tfenv")
+	if err := os.WriteFile(
+		src, []byte("fake binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(tmpDir, "terraform")
+
+	// Simulate hardlink creation.
+	if err := os.Link(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	if !isSameFile(src, dst) {
+		t.Error("hardlink should produce same file")
+	}
+}
+
+func TestRunInit_FallbackToCopy(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "tfenv")
+	content := []byte("fake binary content")
+	if err := os.WriteFile(src, content, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	dst := filepath.Join(tmpDir, "terraform")
+	if err := copyFile(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(got) != string(content) {
+		t.Error("copy fallback should produce identical content")
+	}
+}
+
+func TestRunInit_Idempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	src := filepath.Join(tmpDir, "tfenv")
+	dst := filepath.Join(tmpDir, "terraform")
+
+	if err := os.WriteFile(
+		src, []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create hardlink first time.
+	if err := os.Link(src, dst); err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify isSameFile detects idempotency.
+	if !isSameFile(src, dst) {
+		t.Error("should detect same file for idempotency check")
+	}
+}
+
+// --- Stdout contamination test ---
+
+func TestRun_NoStdoutContamination(t *testing.T) {
+	// Capture stdout to verify the shim never writes to it.
+	// We redirect os.Stdout to a pipe and check nothing was written.
+	origStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+
+	tmpDir := t.TempDir()
+	configDir := filepath.Join(tmpDir, "config")
+	workDir := filepath.Join(tmpDir, "work")
+
+	if err := os.MkdirAll(
+		filepath.Join(configDir, "versions"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(workDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("TFENV_CONFIG_DIR", configDir)
+	t.Setenv("TFENV_TERRAFORM_VERSION", "1.5.0")
+	t.Setenv("TFENV_AUTO_INSTALL", "false")
+	t.Setenv("HOME", tmpDir)
+
+	origDir, _ := os.Getwd()
+	if err := os.Chdir(workDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Run the shim (will fail because version not installed).
+	_ = Run([]string{"version"})
+
+	// Close write end and read what was captured.
+	w.Close()
+	os.Stdout = origStdout
+
+	buf := make([]byte, 1024)
+	n, _ := r.Read(buf)
+	r.Close()
+
+	if n > 0 {
+		t.Errorf(
+			"shim wrote %d bytes to stdout: %q — "+
+				"all output must go to stderr",
+			n, string(buf[:n]))
 	}
 }


### PR DESCRIPTION
Implements #502 — terraform shim (multi-call binary) with version resolution, auto-install, and tfenv init.

## Changes

### Shim (`internal/shim/shim.go`)
- Full terraform shim: resolve version from file chain → keyword resolution against local versions → auto-install → exec real binary
- `-chdir=<dir>` detection sets `cfg.Dir` for correct version file resolution
- All output to stderr (never stdout) — critical for `terraform output` and machine-readable commands

### Platform-specific exec
- `exec_unix.go`: `syscall.Exec` replaces the process (no child process overhead, signals go directly to terraform)
- `exec_windows.go`: `os/exec.Command` with stdin/stdout/stderr passthrough and exit code forwarding

### `tfenv init` command (`init_command.go`)
- Creates `terraform` hardlink next to the `tfenv` binary
- Falls back to file copy if hardlinks are unsupported
- Idempotent: detects existing same-file link and reports success

### `main.go` update
- Strips `.exe` suffix on Windows for correct multi-call basename matching

## Tests (19 tests)
- `extractChdir`: present, absent, empty, multiple args, relative paths
- `isExactVersion`: exact versions vs keywords
- `terraformBinaryPath`: correct path construction
- `Run` integration tests: no version file, missing version, -chdir handling, keyword resolution
- `isSameFile`, `copyFile`, init helpers, idempotency
- Stdout contamination check: verifies zero bytes to stdout

## Verification
- `go vet ./...` — clean
- `go test ./...` — all packages pass
- `go test -race ./...` — no race conditions
- Manual test: built binary, invoked as `terraform`, auto-installed and exec'd real terraform successfully
- Manual test: `tfenv init` creates hardlink, idempotent re-run succeeds

Closes #502