### PR TITLE
[STACKED] feat: goreleaser configuration for cross-platform distribution

### DIFF
--- a/go/.goreleaser.yml
+++ b/go/.goreleaser.yml
@@ -1,0 +1,133 @@
+version: 2
+
+project_name: tfenv
+
+dist: ../dist
+
+builds:
+  - id: tfenv
+    dir: .
+    main: ./cmd/tfenv
+    binary: tfenv
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+      - freebsd
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - "7"
+    ignore:
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+  # Second build: the terraform shim entry point.
+  # Same source as tfenv — multi-call dispatch uses the invoked basename
+  # to decide whether to act as the CLI or the terraform shim.
+  - id: terraform-shim
+    dir: .
+    main: ./cmd/tfenv
+    binary: terraform
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+      - freebsd
+    goarch:
+      - amd64
+      - arm64
+      - arm
+    goarm:
+      - "7"
+    ignore:
+      - goos: darwin
+        goarch: arm
+      - goos: windows
+        goarch: arm
+      - goos: freebsd
+        goarch: arm
+      - goos: freebsd
+        goarch: arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - id: default
+    builds:
+      - tfenv
+      - terraform-shim
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - src: ../LICENSE
+        dst: .
+      - src: ../README.md
+        dst: .
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+nfpms:
+  - id: packages
+    package_name: tfenv-go
+    vendor: tfutils
+    homepage: https://github.com/tfutils/tfenv
+    maintainer: Mike Peachey <mike.peachey@bjss.com>
+    description: Terraform version manager (Go edition)
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/local/bin
+    contents:
+      - src: ../LICENSE
+        dst: /usr/share/doc/tfenv-go/LICENSE
+      - src: ../README.md
+        dst: /usr/share/doc/tfenv-go/README.md
+
+brews:
+  - name: tfenv-go
+    repository:
+      owner: tfutils
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: https://github.com/tfutils/tfenv
+    description: Terraform version manager (Go edition)
+    license: MIT
+    install: |
+      bin.install "tfenv"
+      bin.install "terraform"
+    test: |
+      system "#{bin}/tfenv", "--version"
+    skip_upload: auto
+
+release:
+  draft: true
+  name_template: "tfenv {{.Version}}"
+
+changelog:
+  use: github-native

--- a/go/cmd/tfenv/main.go
+++ b/go/cmd/tfenv/main.go
@@ -25,9 +25,13 @@ import (
 	_ "github.com/tfutils/tfenv/go/internal/use"
 )
 
-// version is set at build time via -ldflags "-X main.version=...".
-// It defaults to "dev" for local builds.
-var version = "dev"
+// Build-time variables injected via -ldflags.
+// Defaults are used for local `go build` invocations.
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
 
 func main() {
 	basename := filepath.Base(os.Args[0])
@@ -41,6 +45,11 @@ func main() {
 	case "terraform":
 		os.Exit(shim.Run(os.Args[1:]))
 	default:
-		os.Exit(cli.Run(version, os.Args[1:]))
+		info := cli.BuildInfo{
+			Version: version,
+			Commit:  commit,
+			Date:    date,
+		}
+		os.Exit(cli.Run(info, os.Args[1:]))
 	}
 }

--- a/go/internal/cli/cli.go
+++ b/go/internal/cli/cli.go
@@ -32,11 +32,18 @@ func Register(name string, description string, handler Handler) {
 	}
 }
 
+// BuildInfo holds version metadata injected at build time.
+type BuildInfo struct {
+	Version string
+	Commit  string
+	Date    string
+}
+
 // Run dispatches to the appropriate subcommand based on args.
 // It returns an exit code suitable for os.Exit.
-func Run(version string, args []string) int {
+func Run(info BuildInfo, args []string) int {
 	if len(args) == 0 {
-		printUsage(version)
+		printUsage(info.Version)
 		return 0
 	}
 
@@ -44,13 +51,13 @@ func Run(version string, args []string) int {
 
 	// Handle --version and version as special cases.
 	if subcmd == "--version" || subcmd == "version" {
-		fmt.Fprintf(os.Stdout, "tfenv %s\n", version)
+		fmt.Fprintf(os.Stdout, "tfenv %s (commit: %s, built: %s)\n", info.Version, info.Commit, info.Date)
 		return 0
 	}
 
 	// Handle help as a special case.
 	if subcmd == "help" || subcmd == "--help" || subcmd == "-h" {
-		printUsage(version)
+		printUsage(info.Version)
 		return 0
 	}
 

--- a/go/internal/cli/cli_test.go
+++ b/go/internal/cli/cli_test.go
@@ -4,36 +4,38 @@ import (
 	"testing"
 )
 
+var testInfo = BuildInfo{Version: "1.2.3", Commit: "abc123", Date: "2025-01-01"}
+
 func TestRunVersion(t *testing.T) {
-	exit := Run("1.2.3", []string{"--version"})
+	exit := Run(testInfo, []string{"--version"})
 	if exit != 0 {
 		t.Errorf("expected exit code 0, got %d", exit)
 	}
 }
 
 func TestRunVersionSubcommand(t *testing.T) {
-	exit := Run("1.2.3", []string{"version"})
+	exit := Run(testInfo, []string{"version"})
 	if exit != 0 {
 		t.Errorf("expected exit code 0, got %d", exit)
 	}
 }
 
 func TestRunHelp(t *testing.T) {
-	exit := Run("1.2.3", []string{"help"})
+	exit := Run(testInfo, []string{"help"})
 	if exit != 0 {
 		t.Errorf("expected exit code 0, got %d", exit)
 	}
 }
 
 func TestRunNoArgs(t *testing.T) {
-	exit := Run("1.2.3", []string{})
+	exit := Run(testInfo, []string{})
 	if exit != 0 {
 		t.Errorf("expected exit code 0, got %d", exit)
 	}
 }
 
 func TestRunUnknownCommand(t *testing.T) {
-	exit := Run("1.2.3", []string{"unknown-command"})
+	exit := Run(testInfo, []string{"unknown-command"})
 	if exit != 1 {
 		t.Errorf("expected exit code 1, got %d", exit)
 	}
@@ -47,7 +49,7 @@ func TestRegisterAndRun(t *testing.T) {
 		delete(registry, "test-cmd")
 	}()
 
-	exit := Run("1.2.3", []string{"test-cmd"})
+	exit := Run(testInfo, []string{"test-cmd"})
 	if exit != 0 {
 		t.Errorf("expected exit code 0, got %d", exit)
 	}

--- a/go/scripts/post-build.sh
+++ b/go/scripts/post-build.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Create the terraform entry point alongside tfenv after a manual local build.
+#
+# goreleaser uses a dual-build approach (see .goreleaser.yml) so this script
+# is only needed for manual `go build` workflows outside goreleaser.
+#
+# The terraform binary is a copy of tfenv — multi-call dispatch uses the
+# invoked basename to decide whether to act as tfenv CLI or terraform shim.
+
+set -eu
+
+src="${1:-tfenv}"
+dir="$(dirname "${src}")"
+
+if [ -f "${src}" ]; then
+  cp "${src}" "${dir}/terraform"
+  echo "Created ${dir}/terraform"
+elif [ -f "${src}.exe" ]; then
+  cp "${src}.exe" "${dir}/terraform.exe"
+  echo "Created ${dir}/terraform.exe"
+else
+  echo "Error: ${src} not found. Build tfenv first:" >&2
+  echo "  go build -o tfenv ./cmd/tfenv" >&2
+  exit 1
+fi


### PR DESCRIPTION
Implements #503 — goreleaser v2 configuration for the Go edition.

## Changes

- `go/.goreleaser.yml` — goreleaser v2 config with dual-build approach
  - **tfenv** build + **terraform-shim** build (same source, different binary name)
  - CGO_ENABLED=0 static binaries
  - Platforms: linux, darwin, windows, freebsd
  - Architectures: amd64, arm64, arm/v7
  - .tar.gz for Unix, .zip for Windows
  - deb/rpm packages via nfpms
  - Homebrew formula generation for tfutils/homebrew-tap
  - SHA256 checksums
  - Draft releases with github-native changelog
- `go/cmd/tfenv/main.go` — added `commit` and `date` build-time variables
- `go/internal/cli/cli.go` — `BuildInfo` struct for version metadata; `--version` now shows commit and build date
- `go/internal/cli/cli_test.go` — updated tests for `BuildInfo`
- `go/scripts/post-build.sh` — helper for manual local builds (creates terraform shim copy)

## Design Decision

Used a **dual-build** approach instead of post-build hooks to include both `tfenv` and `terraform` binaries in each archive. goreleaser natively handles multiple builds in a single archive, making this cleaner and more reliable than hook-based file copying.

## Stacked On

`feat/488-go-edition`

Closes #503