### PR TITLE
fix: install lock misreads missing parent dir as contention

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -98,11 +98,21 @@ declare lockdir="${TFENV_CONFIG_DIR}/.install-lock-${version}";
 declare lock_retries=0;
 declare lock_max_retries=60;
 
+# Ensure the config dir exists so the lock mkdir can succeed on a first install.
+# Without this, mkdir fails with ENOENT and the loop below misreads it as contention.
+mkdir -p "${TFENV_CONFIG_DIR}" || log 'error' "Failed to create ${TFENV_CONFIG_DIR}";
+
 cleanup_lock() {
   rmdir "${lockdir}" 2>/dev/null || true;
 };
 
 while ! mkdir "${lockdir}" 2>/dev/null; do
+  # Distinguish "lock held" (lockdir exists) from any other mkdir failure
+  # (missing parent, permissions, full disk, etc.) so we fail loud instead
+  # of looping silently for 60s on an unrecoverable error.
+  if [ ! -d "${lockdir}" ]; then
+    log 'error' "Failed to create lock directory ${lockdir} — check that ${TFENV_CONFIG_DIR} exists and is writable";
+  fi;
   if [ "${lock_retries}" -eq 0 ]; then
     log 'info' "Another process is installing Terraform v${version}. Waiting...";
   fi;


### PR DESCRIPTION
## Description

`tfenv install` was locked waiting to install the terraform version with the message "Another process is installing
Terraform v… Waiting…" this was on an existing install of tfenv where `${TFENV_CONFIG_DIR}` did not exist yet. 

Root cause: `libexec/tfenv-install` acquires its per-version lock with
`mkdir "${lockdir}" 2>/dev/null` (no `-p`). When the parent config dir
is missing, mkdir fails with ENOENT, but `2>/dev/null` swallows the
error and the loop misreads it as lock contention. After 60s it falls
through to the "stale lock" branch, retries once more, and fails — all
without ever signalling the real problem.

This change makes two targeted fixes:

1. `mkdir -p "${TFENV_CONFIG_DIR}"` before the lock loop, so first-run
   installs with no pre-existing config dir succeed.
2. Inside the loop, distinguish "lock held" (lockdir exists after the
   failed mkdir) from any other mkdir failure (missing parent, EACCES,
   ENOSPC, …) and `log 'error'` immediately on the latter, instead of
   looping silently for 60s on an unrecoverable error.

Both `mkdir -p` and `[ -d ]` are POSIX, so the change is portable across
Linux, macOS, BSDs, and Windows MSYS/MinGW/Cygwin — the same set the
existing lock idiom already runs on.

## Issue Link

Closes https://github.com/tfutils/tfenv/issues/487 https://github.com/tfutils/tfenv/issues/525

## Testing

- [x] Ran `./test/run.sh` locally and all tests pass
- [ ] Reproduced original bug by removing `~/.config/tfenv/` then
      running `tfenv install <version>`; confirmed it fails fast on
      `master` and succeeds on this branch.
- [x] Tested on at least one platform (note which below)
- [ ] New tests added for new functionality (if applicable)

**Platform tested:** <!-- e.g. macOS 14 -->

- [x] macOS 26.4.1 (25E253)

## Quality Checklist

- [x] Shell quoting verified — all variables quoted, braces used
- [x] Cross-platform considered — `mkdir -p` and `[ -d ]` are POSIX
- [x] No unintended changes to other commands
- [ ] README.md updated (if user-facing change) — n/a, no docs change
- [ ] CHANGELOG.md updated (if notable change) — recommend a brief
      "Fixed" entry under the next release


## AI usage 

This code was reviewed for correctness & the PR summary was generated using Claude model Opus 4.7 with 1M context , the code absent of comments was written by a human. 