### PR TITLE
Release v3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1 (April 28, 2026)
+
+ * FIX: Install lock misreads missing config parent dir as contention, blocking first-run installs via Homebrew on macOS, fixing #487 and #525 (Gavin Elder <gavin.elder@seqera.io>)
+
 ## 3.2.0 (April 24, 2026)
 
  * NEW FEATURE: Support comments in `.terraform-version` files — lines starting with `#` and inline `#` comments are stripped, fixing #391 and #283 (Mike Peachey <mike.peachey@bjss.com>)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache --purge \
     curl \
     ;
 
-ARG TFENV_VERSION=3.2.0
+ARG TFENV_VERSION=3.2.1
 RUN wget -O /tmp/tfenv.tar.gz "https://github.com/tfutils/tfenv/archive/refs/tags/v${TFENV_VERSION}.tar.gz" \
     && tar -C /tmp -xf /tmp/tfenv.tar.gz \
     && mv "/tmp/tfenv-${TFENV_VERSION}/bin"/* /usr/local/bin/ \


### PR DESCRIPTION
## Release v3.2.1

### Changes

* **FIX:** Install lock misreads missing config parent dir as contention, blocking first-run installs via Homebrew on macOS, fixing #487 and #525 (Gavin Elder)

### Checklist

- [x] CHANGELOG.md updated with new `3.2.1` section
- [x] Dockerfile version bumped to `3.2.1`
- [ ] After merge: tag `v3.2.1` on merge commit and create GitHub Release