### PR TITLE
Release v3.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.2 (April 28, 2026)
+
+ * FIX: Fail fast with precise diagnostics when TFENV_CONFIG_DIR is not writable, instead of misreporting lock contention for 60s; offer interactive fallback to ~/.tfenv (#524)
+
 ## 3.2.1 (April 28, 2026)
 
  * FIX: Install lock misreads missing config parent dir as contention, blocking first-run installs via Homebrew on macOS, fixing #487 and #525 (Gavin Elder <gavin.elder@seqera.io>)

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache --purge \
     curl \
     ;
 
-ARG TFENV_VERSION=3.2.1
+ARG TFENV_VERSION=3.2.2
 RUN wget -O /tmp/tfenv.tar.gz "https://github.com/tfutils/tfenv/archive/refs/tags/v${TFENV_VERSION}.tar.gz" \
     && tar -C /tmp -xf /tmp/tfenv.tar.gz \
     && mv "/tmp/tfenv-${TFENV_VERSION}/bin"/* /usr/local/bin/ \


### PR DESCRIPTION
## Release v3.2.2

### Changes since v3.2.1

* **FIX:** Fail fast with precise diagnostics when `TFENV_CONFIG_DIR` is not writable, instead of misreporting lock contention for 60s; offer interactive fallback to `~/.tfenv` (#524)

### Checklist

- [x] CHANGELOG.md updated with v3.2.2 section
- [x] Dockerfile bumped to 3.2.2
- [ ] Merge this PR, then tag `v3.2.2` on the merge commit and create GitHub Release