### PR TITLE
Fix #533: pipe SHA256SUMS into checksum tool instead of process substitution

### DIFF
--- a/libexec/tfenv-install
+++ b/libexec/tfenv-install
@@ -379,17 +379,15 @@ fi;
 if [[ -n "${shasum_bin}" && -x "${shasum_bin}" ]]; then
   (
     cd "${download_tmp}";
-    "${shasum_bin}" \
-      -a 256 \
-      -s \
-      -c <(grep -F "${tarball_name}" "${shasums_name}")
+    grep -F "${tarball_name}" "${shasums_name}" \
+      | "${shasum_bin}" -a 256 -s -c -
   ) && log 'info' 'SHA256 hash matched!' \
     || log 'error' 'SHA256 hash does not match!';
 elif [[ -n "${sha256sum_bin}" && -x "${sha256sum_bin}" ]]; then
   (
     cd "${download_tmp}";
-    "${sha256sum_bin}" \
-      -c <(grep -F "${tarball_name}" "${shasums_name}")
+    grep -F "${tarball_name}" "${shasums_name}" \
+      | "${sha256sum_bin}" -c -
   ) && log 'info' 'SHA256 hash matched!' \
     || log 'error' 'SHA256 hash does not match!';
 else


### PR DESCRIPTION
## Description

The SHA256 verification step in `tfenv install` used bash process substitution to feed the filtered SHA256SUMS line into `sha256sum` (or `shasum`):

    "${sha256sum_bin}" -c <(grep -F "${tarball_name}" "${shasums_name}")

This relies on `/dev/fd/N` being resolvable, which is not the case in some sandboxed container runtimes (AWS Lambda being the reported one in #533). In those environments `sha256sum` fails with

    sha256sum: /dev/fd/63: No such file or directory
    SHA256 hash does not match!

…even though the downloaded tarball is fine, and `tfenv install` then aborts before unzipping the binary.

Piping the filtered line in over stdin avoids `/dev/fd` entirely and is portable across BSD `shasum` (Perl), GNU `sha256sum` (coreutils), and macOS `shasum`, all of which accept `-c -` to read checksums from stdin.

Verified by running `./test/run.sh` locally on Linux (Fedora 43, bash 5.2) — all test suites pass, with the patched verification firing on every `tfenv install` performed by the suite.

## Issue Link

Closes #533 

## Testing

- [x] Ran ./test/run.sh locally and all tests pass — yes. Full suite ran on this machine; every SHA256 hash matched! line in the output confirms the new pipe form works across all install paths (latest, latest-allowed, min-required, auto-install, multi-version uninstall, etc.).
- [x] Tested on at least one platform — Linux x86_64, Fedora 43, bash 5.2.32.
- [ ] New tests added for new functionality — N/A. This is a bug fix, not new functionality. The existing test_install_and_use.sh already exercises the fixed code path on every run. A test that reproduces the original failure would have to simulate a runtime without /dev/fd/N, which their suite isn't set up for (and which I couldn't reliably reproduce with plain Docker either).

**Platform tested:** Fedora 43 (Linux x86_64), bash 5.2.32, GNU coreutils sha256sum.

## Quality Checklist

- [x] Shell quoting verified — every variable in the touched lines is "${braced}". The pipe doesn't introduce any unquoted expansion.
- [x] Cross-platform considered (BSD vs GNU) — both code paths use -c -, which is supported by:
  - GNU sha256sum (coreutils)
  - Perl shasum (Digest::SHA, default on macOS and BSD) — Debian manpage confirms "With no FILE, or when FILE is -, read standard input."
- [x] No unintended changes to other commands — diff touches libexec/tfenv-install only, lines 379–393, leaves the surrounding &&/|| flow and the no-shasum-available else branch untouched.
- [ ] README.md updated — N/A. No user-facing behaviour or interface change.
- [ ] CHANGELOG.md updated — not done. Maintainers (Mike Peachey & co.) seem to roll CHANGELOG entries in at release time — there's no ## Unreleased section. I'd note in the PR description "happy to add a CHANGELOG entry if preferred." If you'd rather pre-empt that, the appropriate line would be something like:

 * FIX: Use a stdin pipe instead of bash process substitution for SHA256 verification, allowing `tfenv install` to work in container runtimes that don't expose /dev/fd (e.g. AWS Lambda), fixing #533