### PR TITLE
Added unzip to check_dependencies

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -153,13 +153,13 @@ export -f check_default_version;
 function cleanup() {
   log 'info' 'Performing cleanup';
   local pwd="$(pwd)";
-  
+
   # Safety check to ensure TFENV_CONFIG_DIR is set and not empty
   if [ -z "${TFENV_CONFIG_DIR:-""}" ]; then
     log 'error' 'TFENV_CONFIG_DIR is not set, cannot perform cleanup safely';
     return 1;
   fi;
-  
+
   log 'debug' "Deleting ${TFENV_CONFIG_DIR}/version";
   rm -rf "${TFENV_CONFIG_DIR}/version";
   log 'debug' "Deleting ${TFENV_CONFIG_DIR}/version.prev";
@@ -199,6 +199,10 @@ function check_dependencies() {
     fi;
 
     log 'error' 'GNU Grep is a requirement and your Mac does not have it. Consider "brew install grep" or "nix profile install nixpkgs#gnugrep"';
+  fi;
+
+  if ! command -v unzip >/dev/null 2>&1; then
+      log 'error' 'unzip is a requirement and your device does not have it. Install unzip using your preferred method.'
   fi;
 };
 export -f check_dependencies;

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -202,7 +202,7 @@ function check_dependencies() {
   fi;
 
   if ! command -v unzip >/dev/null 2>&1; then
-      log 'error' 'unzip is a requirement and your device does not have it. Install unzip using your preferred method.'
+      log 'error' 'unzip is a requirement and your device does not have it. Install unzip using your preferred method.';
   fi;
 };
 export -f check_dependencies;


### PR DESCRIPTION
## Description

This PR adds a check for existence of the `unzip` binary in `check_dependencies` to fail early when unzip is not present and give a more explicit error message.

While it's uncommon for systems to not have `unzip` present, a fresh installation of WSL does not have unzip, at least in my distribution. The current behavior goes as follows:

```
user@computer:~/Projects/tfenv$ tfenv install 1.15.2
tfenv: Installing Terraform v1.15.2
tfenv: Downloading release tarball from https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_linux_amd64.zip
################################################################################################################################################################################################################################## 100.0%
tfenv: Downloading SHA hash file from https://releases.hashicorp.com/terraform/1.15.2/terraform_1.15.2_SHA256SUMS
tfenv: Not instructed to use Local PGP (/home/elias/.tfenv/use-{gpgv,gnupg}) & No keybase install found, skipping OpenPGP signature verification
tfenv: SHA256 hash matched!
/home/elias/.tfenv/libexec/tfenv-install: line 403: unzip: command not found
tfenv: [ERROR] Tarball unzip failed
```

With this change, a check runs before attempting to unzip (by the already present `check_dependencies`). The new user experience is:

```
user@computer:~/Projects/tfenv$ ./bin/tfenv install 1.15.2
tfenv: [ERROR] unzip is a requirement and your device does not have it. Install unzip using your preferred method.
tfenv: [ERROR] Failed to resolve 1.15.2 version
```

`command` is present on `sh`, so it should be usable in BSD systems. I have however not checked in an actual BSD-based system.

## Issue Link

I have not created an issue for this PR.

## Testing

- [x] Ran `./test/run.sh` locally and all tests pass
- [x] Tested on at least one platform (note which below)
- [ ] New tests added for new functionality (if applicable)

**Platform tested:** <!-- e.g. Ubuntu 22.04, macOS 14 -->

## Quality Checklist

- [x] Shell quoting verified — all variables quoted, braces used
- [x] Cross-platform considered — BSD vs GNU tool differences
- [x] No unintended changes to other commands
- [ ] README.md updated (if user-facing change)
- [ ] CHANGELOG.md updated (if notable change)

### Disclaimer

This is my first contribution to this project, sorry if something is off standard, I tried to follow the README.md on contributing. Cheers!